### PR TITLE
Avoid returning an error on invalid PF

### DIFF
--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -184,11 +184,7 @@ func getFilteredPFs(pfList *[]netlink.Link) error {
 	for i := 0; i < len(linkList); i++ {
 		result, err := isPF(linkList[i].Attrs().Name)
 
-		if err != nil {
-			return fmt.Errorf("unable to check if PF: %v", err)
-		}
-
-		if result {
+		if result && err == nil {
 			*pfList = append(*pfList, linkList[i])
 		}
 	}


### PR DESCRIPTION
Removes error return when not a valid PF.