### PR TITLE
Updated paths from linux_networking to rh_mvp

### DIFF
--- a/ipu-plugin/Makefile
+++ b/ipu-plugin/Makefile
@@ -52,7 +52,7 @@ test:
 	@go test -cover ./...
 
 image:
-	cp -r ../e2e/artefacts/p4 $(CURDIR)
+	cp -r ../e2e/artefacts/p4-rh_mvp $(CURDIR)
 	$(IMGTOOL) build -t $(IMAGE_TAG_VERSION) -f $(DOCKERFILE)  $(CURDIR) $(DOCKERARGS) --no-cache
 	$(IMGTOOL) image tag $(IMAGE_TAG_VERSION) $(IMAGE_TAG_LATEST)
 
@@ -61,7 +61,7 @@ PLATFORMS ?= linux/arm64,linux/amd64
 # 	docker buildx create --use --driver-opt env.http_proxy=$(HTTP_PROXY) --driver-opt env.https_proxy=$(HTTPS_PROXY) --driver-opt env.no_proxy=$(NO_PROXY)
 # buildkit.toml file is a configuration file which allows to set registry configuration
 imagex: ## Build and push docker image for the manager for cross-platform support
-	cp -r ../e2e/artefacts/p4 $(CURDIR)
+	cp -r ../e2e/artefacts/p4-rh_mvp $(CURDIR)
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' $(DOCKERFILE) > $(DOCKERFILE).cross
 	- $(IMGTOOL) buildx create --name image-builder --use --config=buildkit.toml --buildkitd-flags '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host' --driver-opt env.http_proxy=$(HTTP_PROXY) --driver-opt env.https_proxy=$(HTTPS_PROXY)'"'

--- a/ipu-plugin/images/Dockerfile
+++ b/ipu-plugin/images/Dockerfile
@@ -13,11 +13,10 @@ WORKDIR /usr/src/ipu-opi-plugin
 RUN go mod download
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin/ipuplugin ipuplugin/main.go
 
-
 FROM alpine:3@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 
 COPY --from=builder /usr/src/ipu-opi-plugin/bin/ipuplugin /usr/bin/
-COPY p4/linux_networking.s/linux_networking.pkg /
+COPY p4-rh_mvp/rh_mvp.pkg /
 WORKDIR /
 LABEL io.k8s.display-name="IPU OPI Plugin"
 

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -280,7 +280,7 @@ func (s *SSHHandlerImpl) sshFunc() error {
 	defer sftpClient.Close()
 
 	// Open the source file.
-	localFilePath := "/linux_networking.pkg"
+	localFilePath := "/rh_mvp.pkg"
 	srcFile, err := os.Open(localFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to open local file: %s", err)
@@ -288,7 +288,7 @@ func (s *SSHHandlerImpl) sshFunc() error {
 	defer srcFile.Close()
 
 	// Create the destination file on the remote server.
-	remoteFilePath := "/work/scripts/linux_networking.pkg"
+	remoteFilePath := "/work/scripts/rh_mvp.pkg"
 	dstFile, err := sftpClient.Create(remoteFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create remote file: %s", err)
@@ -358,11 +358,11 @@ cd $CURDIR
 	shellScript := fmt.Sprintf(`#!/bin/sh
 	CP_INIT_CFG=/etc/dpcp/cfg/cp_init.cfg
 	echo "Checking for custom package..."
-	if [ -e linux_networking.pkg ]; then
-		echo "Custom package linux_networking.pkg found. Overriding default package"
-		cp linux_networking.pkg /etc/dpcp/package/
+	if [ -e rh_mvp.pkg ]; then
+		echo "Custom package rh_mvp.pkg found. Overriding default package"
+		cp rh_mvp.pkg /etc/dpcp/package/
 		rm -rf /etc/dpcp/package/default_pkg.pkg
-		ln -s /etc/dpcp/package/linux_networking.pkg /etc/dpcp/package/default_pkg.pkg
+		ln -s /etc/dpcp/package/rh_mvp.pkg /etc/dpcp/package/default_pkg.pkg
 		sed -i 's/sem_num_pages = 1;/sem_num_pages = 25;/g' $CP_INIT_CFG
 		sed -i 's/pf_mac_address = "00:00:00:00:03:14";/pf_mac_address = "%s";/g' $CP_INIT_CFG
 		sed -i 's/acc_apf = 4;/acc_apf = 19;/g' $CP_INIT_CFG


### PR DESCRIPTION
This PR updates the paths in the ipu-plugin to replace the linux_networking recipe artefacts.