### PR TITLE
limit plugin daemonset to run on worker nodes only

### DIFF
--- a/e2e/artefacts/k8s/vsp-ds.yaml
+++ b/e2e/artefacts/k8s/vsp-ds.yaml
@@ -11,6 +11,15 @@ spec:
       labels:
         name: vsp
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
       hostNetwork: true
       automountServiceAccountToken: false
       containers:


### PR DESCRIPTION
limit plugin daemonset to run on worker nodes only using node anti-affinity.