### PR TITLE
Fix lifecycleservice unit test

### DIFF
--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -106,6 +106,10 @@ type SSHHandler interface {
 
 type SSHHandlerImpl struct{}
 
+type FXPHandler interface {
+	configureFXP()
+}
+
 var fileSystemHandler FileSystemHandler
 var networkHandler NetworkHandler
 var executableHandler ExecutableHandler

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -107,13 +107,16 @@ type SSHHandler interface {
 type SSHHandlerImpl struct{}
 
 type FXPHandler interface {
-	configureFXP()
+	configureFXP(p4rtbin string) error
 }
+
+type FXPHandlerImpl struct{}
 
 var fileSystemHandler FileSystemHandler
 var networkHandler NetworkHandler
 var executableHandler ExecutableHandler
 var sshHandler SSHHandler
+var fxpHandler FXPHandler
 
 func initHandlers() {
 	if fileSystemHandler == nil {
@@ -127,6 +130,9 @@ func initHandlers() {
 	}
 	if sshHandler == nil {
 		sshHandler = &SSHHandlerImpl{}
+	}
+	if fxpHandler == nil {
+		fxpHandler = &FXPHandlerImpl{}
 	}
 }
 
@@ -482,6 +488,23 @@ func (e *ExecutableHandlerImpl) validate() bool {
 	return true
 }
 
+func (s *FXPHandlerImpl) configureFXP(p4rtbin string) error {
+	vfMacList, err := utils.GetVfMacList()
+
+	if err != nil {
+		return fmt.Errorf("unable to reach the IMC %v", err)
+	}
+
+	if len(vfMacList) == 0 {
+		return fmt.Errorf("no NFs initialized on the host")
+	}
+
+	p4rtclient.DeletePointToPointVFRules(p4rtbin, vfMacList)
+	p4rtclient.CreatePointToPointVFRules(p4rtbin, vfMacList)
+
+	return nil
+}
+
 func (s *LifeCycleServiceServer) Init(ctx context.Context, in *pb.InitRequest) (*pb.IpPort, error) {
 	initHandlers()
 
@@ -499,19 +522,10 @@ func (s *LifeCycleServiceServer) Init(ctx context.Context, in *pb.InitRequest) (
 			log.Info("not forcing state")
 		}
 
-		vfMacList, err := utils.GetVfMacList()
-
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Unable to reach the IMC %v", err)
-		}
-
-		if len(vfMacList) == 0 {
-			return nil, status.Error(codes.Internal, "No NFs initialized on the host")
-		}
-
 		// Preconfigure the FXP with point-to-point rules between host VFs
-		p4rtclient.DeletePointToPointVFRules(s.p4rtbin, vfMacList)
-		p4rtclient.CreatePointToPointVFRules(s.p4rtbin, vfMacList)
+		if err := fxpHandler.configureFXP(s.p4rtbin); err != nil {
+			return nil, status.Errorf(codes.Internal, "Error when preconfiguring the FXP: %v", err)
+		}
 	}
 
 	if err := configureChannel(s.mode, s.daemonHostIp, s.daemonIpuIp); err != nil {

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice_test.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice_test.go
@@ -31,6 +31,7 @@ var _ = Describe("basic functionality", Serial, func() {
 	fileSystemHandler = &MockFileSystemHandlerImpl{}
 	networkHandler = &MockNetworkHandlerImpl{}
 	executableHandler = &MockExecutableHandlerImpl{}
+	fxpHandler = &MockFXPHandlerImpl{}
 
 	Describe("pf communication channel setup", Serial, func() {
 
@@ -255,4 +256,10 @@ type MockExecutableHandlerImpl struct{}
 
 func (m *MockExecutableHandlerImpl) validate() bool {
 	return true
+}
+
+type MockFXPHandlerImpl struct{}
+
+func (m *MockFXPHandlerImpl) configureFXP(p4rtbin string) error {
+	return nil
 }


### PR DESCRIPTION
This adds the FXP handler to avoid running the p4rtclient during unit tests.