### PR TITLE
Start new session for subsequent commands

### DIFF
--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -401,6 +401,12 @@ fi
 		return fmt.Errorf("failed to sync uuid file: %s", err)
 	}
 
+	session, err = client.NewSession()
+	if err != nil {
+		return fmt.Errorf("failed to create session: %s", err)
+	}
+	defer session.Close()
+
 	// Run a command on the remote server and capture the output.
 	var stdoutBuf bytes.Buffer
 	session.Stdout = &stdoutBuf


### PR DESCRIPTION
Start a new session to make when making a new call to the Run command. Otherwise we get ssh: sessi
on already started". Session accepts only one call to Run https://pkg.go.dev/golang.org/x/crypto/ssh#Session.Run 