### PR TITLE
Change to use internal interface->enp0s1f0d4(d4), on ACC, for host<->ACC communication

### DIFF
--- a/ipu-plugin/pkg/ipuplugin/deviceplugin.go
+++ b/ipu-plugin/pkg/ipuplugin/deviceplugin.go
@@ -19,9 +19,9 @@ type DevicePluginService struct {
 }
 
 var (
-	exclude     = []string{"enp0s1f0", "enp0s1f0d1", "enp0s1f0d2", "enp0s1f0d3"}
-	sysClassNet = "/sys/class/net"
-	deviceCode  = "0x1452"
+	exclude      = []string{"enp0s1f0", "enp0s1f0d1", "enp0s1f0d2", "enp0s1f0d3", "enp0s1f0d4"}
+	sysClassNet  = "/sys/class/net"
+	deviceCode   = "0x1452"
 	deviceCodeVf = "0x145c"
 )
 

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -47,11 +47,11 @@ type LifeCycleServiceServer struct {
 
 const (
 	hostVportId = "03"
-	accVportId  = "02"
+	accVportId  = "04"
 	deviceId    = "0x1452"
 	vendorId    = "0x8086"
 	imcAddress  = "192.168.0.1:22"
-	apfNumber   = 8
+	apfNumber   = 16
 )
 
 func NewLifeCycleService(daemonHostIp, daemonIpuIp string, daemonPort int, mode string, p4rtbin string) *LifeCycleServiceServer {
@@ -242,6 +242,7 @@ func configureChannel(mode, daemonHostIp, daemonIpuIp string) error {
 	var pfList []netlink.Link
 
 	if err := getFilteredPFs(&pfList); err != nil {
+		fmt.Printf("configureChannel: err->%v from getFilteredPFs", err)
 		return status.Error(codes.Internal, err.Error())
 	}
 
@@ -249,10 +250,12 @@ func configureChannel(mode, daemonHostIp, daemonIpuIp string) error {
 
 	if pf == nil {
 		// Address already set - we don't proceed with setting the ip
+		fmt.Printf("configureChannel: pf nil from getCommPf")
 		return nil
 	}
 
 	if err != nil {
+		fmt.Printf("configureChannel: err->%v from getCommPf", err)
 		return status.Error(codes.Internal, err.Error())
 	}
 
@@ -265,6 +268,7 @@ func configureChannel(mode, daemonHostIp, daemonIpuIp string) error {
 	}
 
 	if err := setIP(pf, ip); err != nil {
+		fmt.Printf("configureChannel: err->%v from setIP", err)
 		return status.Error(codes.Internal, err.Error())
 	}
 
@@ -358,8 +362,8 @@ if [ -e rh_mvp.pkg ]; then
     ln -s /etc/dpcp/package/rh_mvp.pkg /etc/dpcp/package/default_pkg.pkg
     sed -i 's/sem_num_pages = 1;/sem_num_pages = 25;/g' $CP_INIT_CFG
     sed -i 's/pf_mac_address = "00:00:00:00:03:14";/pf_mac_address = "%s";/g' $CP_INIT_CFG
-    sed -i 's/acc_apf = 4;/acc_apf = 8;/g' $CP_INIT_CFG
-    sed -i 's/comm_vports = ((\[5,0\],\[4,0\]));/comm_vports = ((\[5,0\],\[4,0\]),(\[0,3\],\[4,2\]));/g' $CP_INIT_CFG
+    sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
+    sed -i 's/comm_vports = ((\[5,0\],\[4,0\]));/comm_vports = ((\[5,0\],\[4,0\]),(\[0,3\],\[4,4\]));/g' $CP_INIT_CFG
 else
     echo "No custom package found. Continuing with default package"
 fi


### PR DESCRIPTION
Change to use internal interface->enp0s1f0d4(d4), on ACC, for host<->ACC communication. Previously d2 interface was used on ACC, which was meant for external network interface. Using external interface D2 also caused issue when fixed(unique) MAC was set thro fixboard script, since VSP checks for vportid in MAC. Since above change would reduce the number of APFs returned by GetDevices by 1, value of ->acc_apf in node-policy has been increased to 16.