### PR TITLE
Fix for->IIC-364: After host reboot, host connection to ACC is lost

### DIFF
--- a/e2e/artefacts/k8s/vsp-ds.yaml
+++ b/e2e/artefacts/k8s/vsp-ds.yaml
@@ -33,8 +33,13 @@ spec:
         volumeMounts:
         - name: vendor-plugin-sock
           mountPath: /var/run/dpu-daemon/
+        - name: dbus-socket
+          mountPath: /var/run/dbus
       volumes:
       - name: vendor-plugin-sock
         hostPath:
           path: /var/run/dpu-daemon/
+      - name: dbus-socket
+        hostPath:
+          path: /var/run/dbus/
 

--- a/ipu-plugin/images/Dockerfile
+++ b/ipu-plugin/images/Dockerfile
@@ -33,3 +33,4 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages /opt/p4/p4-cp-
 
 RUN rm -rf /var/cache/apk/*
 RUN apk add --update --no-cache openssh
+RUN apk add --update --no-cache networkmanager-cli

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -99,6 +99,7 @@ func (fs *FileSystemHandlerImpl) GetVendor(iface string) ([]byte, error) {
 
 type ExecutableHandler interface {
 	validate() bool
+	nmcliSetup(link netlink.Link) error
 }
 
 type ExecutableHandlerImpl struct{}
@@ -192,18 +193,52 @@ func getCommPf(mode string, linkList []netlink.Link) (netlink.Link, error) {
 	return pf, nil
 }
 
+/*
+It can take time for network-manager's state for each interface, to become
+activated, when IP address is set, which can cause the IP address to not stick.
+Removing the host-acc comm channel interface out of network-manager's mgmt.
+TODO: Currently we only support nmcli/NetworkManager daemon combination(RHEL),
+this api can be extended for other distros that use different CLI/systemd-networkd.
+*/
+func (e *ExecutableHandlerImpl) nmcliSetup(link netlink.Link) error {
+	intfName := link.Attrs().Name
+	output, err := utils.ExecuteScript(`nmcli general status`)
+	if err != nil {
+		log.Infof("nmcli err->%v, output->%v\n", err, output)
+		return nil
+	}
+	output, err = utils.ExecuteScript(`nmcli device set ` + intfName + ` managed no`)
+	if err != nil {
+		log.Errorf("nmcli err->%v, output->%v\n", err, output)
+		return fmt.Errorf("nmcli err->%v, output->%v\n", err, output)
+	}
+	output, err = utils.ExecuteScript(`ip link set ` + intfName + ` up`)
+	if err != nil {
+		log.Errorf("ip link set err->%v, output->%v\n", err, output)
+		return fmt.Errorf("ip link set  err->%v, output->%v\n", err, output)
+	}
+	return nil
+}
+
 func setIP(link netlink.Link, ip string) error {
 	list, err := networkHandler.AddrList(link, netlink.FAMILY_V4)
 
 	if err != nil {
+		log.Errorf("setIP: unable to get the ip address of link: %v\n", err)
 		return fmt.Errorf("unable to get the ip address of link: %v", err)
 	}
 
 	if len(list) == 0 {
 
+		if err = executableHandler.nmcliSetup(link); err != nil {
+			log.Errorf("setIP: err->%v from nmcliSetup\n", err)
+			return fmt.Errorf("setIP: err->%v from nmcliSetup", err)
+		}
+
 		ipAddr := net.ParseIP(ip)
 
 		if ipAddr.To4() == nil {
+			log.Errorf("setIP: invalid ip->%v\n", ipAddr)
 			return fmt.Errorf("not a valid IPv4 address: %v", err)
 		}
 
@@ -211,12 +246,14 @@ func setIP(link netlink.Link, ip string) error {
 		addr := &netlink.Addr{IPNet: &net.IPNet{IP: ipAddr, Mask: net.CIDRMask(24, 32)}}
 
 		if err = networkHandler.AddrAdd(link, addr); err != nil {
+			log.Errorf("setIP: unable to add address: %v\n", err)
 			return fmt.Errorf("unable to add address: %v", err)
 		}
 	} else {
+		log.Errorf("address already set. Unset ip address for interface %s and run again\n", link.Attrs().Name)
 		return fmt.Errorf("address already set. Unset ip address for interface %s and run again", link.Attrs().Name)
 	}
-
+	log.Debugf("setIP: Address->%v, set for interface->%v\n", ip, link.Attrs().Name)
 	return nil
 }
 

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice_test.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice_test.go
@@ -258,6 +258,10 @@ func (m *MockExecutableHandlerImpl) validate() bool {
 	return true
 }
 
+func (e *MockExecutableHandlerImpl) nmcliSetup(link netlink.Link) error {
+	return nil
+}
+
 type MockFXPHandlerImpl struct{}
 
 func (m *MockFXPHandlerImpl) configureFXP(p4rtbin string) error {


### PR DESCRIPTION
It can take time for network-manager's state for each interface, to become activated, when IP address is set, which can cause the IP address to not stick. Removing the host and acc comm channel interfaces out of network-manager's mgmt.