### PR TITLE
Added retry mechanism and nmcli commands to set IP for host-acc comm channel. 

### DIFF
--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice_test.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice_test.go
@@ -258,8 +258,8 @@ func (m *MockExecutableHandlerImpl) validate() bool {
 	return true
 }
 
-func (e *MockExecutableHandlerImpl) nmcliSetup(link netlink.Link) error {
-	return nil
+func (e *MockExecutableHandlerImpl) nmcliSetIPAddress(link netlink.Link, ipAddr string) error {
+	return fmt.Errorf("Method added for test purposes")
 }
 
 type MockFXPHandlerImpl struct{}


### PR DESCRIPTION
Upon host reboot, it seems to take time for network-manager's state for each interface,
to stabilize and become activated. This function does a few retries,
when it tries to set IP.
