### PR TITLE
Add Peer2Peer P4 rules independant of order of deployment, and other fixes.

### DIFF
--- a/e2e/artefacts/k8s/vsp-ds.yaml
+++ b/e2e/artefacts/k8s/vsp-ds.yaml
@@ -50,10 +50,6 @@ spec:
           type: ""
         name: host-opt
       - hostPath:
-          path: /lib/modules
-          type: DirectoryOrCreate
-        name: host-libmodules
-      - hostPath:
           path: /var/run/
           type: ""
         name: vendor-plugin-sock

--- a/e2e/artefacts/k8s/vsp-ds.yaml
+++ b/e2e/artefacts/k8s/vsp-ds.yaml
@@ -22,6 +22,7 @@ spec:
                 operator: DoesNotExist
       hostNetwork: true
       automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 180
       containers:
       - name: appcntr1
         image: silpixa00400458:5000/intel-ipuplugin:latest
@@ -31,15 +32,28 @@ spec:
         command: [ "/usr/bin/ipuplugin" ]
         args: [ "-v=debug"]
         volumeMounts:
-        - name: vendor-plugin-sock
-          mountPath: /var/run/dpu-daemon/
-        - name: dbus-socket
-          mountPath: /var/run/dbus
+        - mountPath: /var/run/
+          name: vendor-plugin-sock
+        - mountPath: /opt/p4/p4-cp-nws/var
+          mountPropagation: Bidirectional
+          name: host-opt
+        - mountPath: /proc
+          mountPropagation: Bidirectional
+          name: host-proc
       volumes:
-      - name: vendor-plugin-sock
-        hostPath:
-          path: /var/run/dpu-daemon/
-      - name: dbus-socket
-        hostPath:
-          path: /var/run/dbus/
-
+      - hostPath:
+          path: /proc
+          type: ""
+        name: host-proc
+      - hostPath:
+          path: /opt/p4/p4-cp-nws/var
+          type: ""
+        name: host-opt
+      - hostPath:
+          path: /lib/modules
+          type: DirectoryOrCreate
+        name: host-libmodules
+      - hostPath:
+          path: /var/run/
+          type: ""
+        name: vendor-plugin-sock

--- a/ipu-plugin/pkg/ipuplugin/bridgeport.go
+++ b/ipu-plugin/pkg/ipuplugin/bridgeport.go
@@ -125,6 +125,8 @@ func (s *server) CreateBridgePort(_ context.Context, in *pb.CreateBridgePortRequ
 		return s.Ports[in.BridgePort.Name].PbBrPort, nil
 	}
 
+	CheckAndAddPeerToPeerP4Rules(s.p4rtbin)
+
 	err, intfName := allocateAccInterface()
 	if err != nil {
 		return nil, fmt.Errorf("error from allocateAccInterface->%v", err)

--- a/ipu-plugin/pkg/ipuplugin/ipuplugin.go
+++ b/ipu-plugin/pkg/ipuplugin/ipuplugin.go
@@ -129,7 +129,7 @@ func (s *server) Stop() {
 		log.Errorf("Unable to reach the IMC %v", err)
 	}
 	if len(vfMacList) == 0 || (len(vfMacList) == 1 && vfMacList[0] == "") {
-		log.Errorf("No NFs initialized on the host")
+		log.Errorf("No VFs initialized on the host")
 	} else {
 		log.Infof("DeletePeerToPeerP4Rules, path->%s, vfMacList->%v", s.p4rtbin, vfMacList)
 		p4rtclient.DeletePeerToPeerP4Rules(s.p4rtbin, vfMacList)

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -850,7 +850,7 @@ func (e *ExecutableHandlerImpl) SetupAccApfs() error {
 
 // If ipu-plugin's Init function gets invoked on ACC, prior to getting invoked
 // on x86, then host VFs will not be setup yet. In that case, peer2peer rules
-// can get added in CreateBridgePort or CreateNetworkFunction.
+// will get added in CreateBridgePort or CreateNetworkFunction.
 func CheckAndAddPeerToPeerP4Rules(p4rtbin string) {
 	if !PeerToPeerP4RulesAdded {
 		vfMacList, err := utils.GetVfMacList()
@@ -860,7 +860,7 @@ func CheckAndAddPeerToPeerP4Rules(p4rtbin string) {
 		}
 		//with use of strings.split in utils, we can get list of length 1 with empty string.
 		if len(vfMacList) == 0 || (len(vfMacList) == 1 && vfMacList[0] == "") {
-			log.Infof("No NFs initialized on the host yet")
+			log.Infof("No VFs initialized on the host yet")
 		} else {
 			log.Infof("AddPeerToPeerP4Rules, path->%s, vfMacList->%v", p4rtbin, vfMacList)
 			p4rtclient.AddPeerToPeerP4Rules(p4rtbin, vfMacList)

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -25,6 +25,7 @@ import (
 	math_rand "math/rand"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -62,6 +63,7 @@ const (
 
 var InitAccApfMacs = false
 var AccApfMacList []string
+var PeerToPeerP4RulesAdded = false
 
 // Reserved ACC interfaces(using vport_id or last digit of interface name, like 4 represents-> enp0s1f0d4)
 const (
@@ -369,28 +371,6 @@ func GetFilteredPFs(pfList *[]netlink.Link) error {
 	return nil
 }
 
-func FindInterfaceIdForGivenMac(macAddr string) (int, error) {
-	intfIndex := 0
-	found := false
-	if !InitAccApfMacs {
-		log.Errorf("FindInterfaceIdForGivenMac: AccApfs info not set, thro-> SetupAccApfs")
-		return 0, fmt.Errorf("FindInterfaceIdForGivenMac: AccApfs info not set, thro-> SetupAccApfs")
-	}
-	for i := 0; i < len(AccApfMacList); i++ {
-		if AccApfMacList[i] == macAddr {
-			intfIndex = i
-			log.Debugf("found intfIndex->%v for mac->%v\n", intfIndex, macAddr)
-			found = true
-			break
-		}
-	}
-	if found == true {
-		return intfIndex, nil
-	}
-	log.Errorf("Couldnt find intfIndex for mac->%v\n", macAddr)
-	return 0, fmt.Errorf("Couldnt find intfIndex for mac->%v\n", macAddr)
-}
-
 func FindInterfaceForGivenMac(macAddr string) (string, error) {
 	var pfList []netlink.Link
 	InitHandlers()
@@ -679,7 +659,7 @@ if [ -e %s ]; then
     sed -i 's/mod_num_pages = 1;/mod_num_pages = 2;/g' $CP_INIT_CFG
     sed -i 's/cxp_num_pages = 1;/cxp_num_pages = 6;/g' $CP_INIT_CFG
     sed -i 's/pf_mac_address = "00:00:00:00:03:14";/pf_mac_address = "%s";/g' $CP_INIT_CFG
-    sed -i 's/acc_apf = 4;/acc_apf = 16;/g' $CP_INIT_CFG
+    sed -i 's/acc_apf = 4;/acc_apf = %s;/g' $CP_INIT_CFG
     sed -i 's/comm_vports = .*/comm_vports = (([5,0],[4,0]),([0,3],[5,3]),([0,2],[4,3]));/g' $CP_INIT_CFG
     sed -i 's/uplink_vports = .*/uplink_vports = ([0,0,0],[0,1,1],[4,1,0],[4,5,1],[5,1,0],[5,2,1]);/g' $CP_INIT_CFG
     sed -i 's/rep_vports = .*/rep_vports = ([0,0,0],[4,5,1]);/g' $CP_INIT_CFG
@@ -687,7 +667,7 @@ if [ -e %s ]; then
 else
     echo "No custom package found. Continuing with default package"
 fi
-`, p4PkgName, p4PkgName, p4PkgName, p4PkgName, macAddress)
+`, p4PkgName, p4PkgName, p4PkgName, p4PkgName, macAddress, strconv.Itoa(ApfNumber))
 
 	return shellScript
 
@@ -832,10 +812,10 @@ func skipIMCReboot() (bool, string) {
 
 func (e *ExecutableHandlerImpl) validate() bool {
 
-	/*Note: Num of APFs gets validated early on,
-	in SetupAccApfs, prior to 1 interface(for Phy Port),
-	getting moved to p4 container in configureFxp */
-
+	if numAPFs := countAPFDevices(); numAPFs < ApfNumber {
+		log.Errorf("Not enough APFs %v, expected->%v", numAPFs, ApfNumber)
+		return false
+	}
 	if noReboot, infoStr := skipIMCReboot(); !noReboot {
 		fmt.Printf("IMC reboot required : %v\n", infoStr)
 		return false
@@ -868,14 +848,28 @@ func (e *ExecutableHandlerImpl) SetupAccApfs() error {
 	return nil
 }
 
+// If ipu-plugin's Init function gets invoked on ACC, prior to getting invoked
+// on x86, then host VFs will not be setup yet. In that case, peer2peer rules
+// can get added in CreateBridgePort or CreateNetworkFunction.
+func CheckAndAddPeerToPeerP4Rules(p4rtbin string) {
+	if !PeerToPeerP4RulesAdded {
+		vfMacList, err := utils.GetVfMacList()
+		if err != nil {
+			log.Errorf("CheckAndAddPeerToPeerP4Rules: unable to reach the IMC %v", err)
+			return
+		}
+		//with use of strings.split in utils, we can get list of length 1 with empty string.
+		if len(vfMacList) == 0 || (len(vfMacList) == 1 && vfMacList[0] == "") {
+			log.Infof("No NFs initialized on the host yet")
+		} else {
+			log.Infof("AddPeerToPeerP4Rules, path->%s, vfMacList->%v", p4rtbin, vfMacList)
+			p4rtclient.AddPeerToPeerP4Rules(p4rtbin, vfMacList)
+			PeerToPeerP4RulesAdded = true
+		}
+	}
+}
+
 func (s *FXPHandlerImpl) configureFXP(p4rtbin string, brCtlr types.BridgeController) error {
-	vfMacList, err := utils.GetVfMacList()
-	if err != nil {
-		return fmt.Errorf("Unable to reach the IMC %v", err)
-	}
-	if len(vfMacList) == 0 {
-		return fmt.Errorf("No NFs initialized on the host")
-	}
 	if !InitAccApfMacs {
 		log.Errorf("configureFXP: AccApfs info not set, thro-> SetupAccApfs")
 		return fmt.Errorf("configureFXP: AccApfs info not set, thro-> SetupAccApfs")
@@ -884,21 +878,14 @@ func (s *FXPHandlerImpl) configureFXP(p4rtbin string, brCtlr types.BridgeControl
 	//Note: Per current design, Phy Port1 is added to a different bridge(through P4 rules).
 	if err := brCtlr.AddPort(AccIntfNames[PHY_PORT0_INTF_INDEX]); err != nil {
 		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[PHY_PORT0_INTF_INDEX])
-		//return fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[PHY_PORT0_INTF_INDEX])
+		return fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[PHY_PORT0_INTF_INDEX])
 	}
 	//Add P4 rules for phy ports
-	log.Infof("DeletePhyPortRules, path->%s, 1->%v, 2->%v", p4rtbin, AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
-	p4rtclient.DeletePhyPortRules(p4rtbin, AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
 	log.Infof("AddPhyPortRules, path->%s, 1->%v, 2->%v", p4rtbin, AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
 	p4rtclient.AddPhyPortRules(p4rtbin, AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
 
-	log.Infof("DeletePeerToPeerP4Rules, path->%s, vfMacList->%v", p4rtbin, vfMacList)
-	p4rtclient.DeletePeerToPeerP4Rules(p4rtbin, vfMacList)
-	log.Infof("AddPeerToPeerP4Rules, path->%s, vfMacList->%v", p4rtbin, vfMacList)
-	p4rtclient.AddPeerToPeerP4Rules(p4rtbin, vfMacList)
+	CheckAndAddPeerToPeerP4Rules(p4rtbin)
 
-	log.Infof("DeleteLAGP4Rules, path->%s", p4rtbin)
-	p4rtclient.DeleteLAGP4Rules(p4rtbin)
 	log.Infof("AddLAGP4Rules, path->%v", p4rtbin)
 	p4rtclient.AddLAGP4Rules(p4rtbin)
 

--- a/ipu-plugin/pkg/ipuplugin/networkfunctionservice.go
+++ b/ipu-plugin/pkg/ipuplugin/networkfunctionservice.go
@@ -54,6 +54,8 @@ func (s *NetworkFunctionServiceServer) CreateNetworkFunction(ctx context.Context
 		return nil, status.Error(codes.Internal, "No NFs initialized on the host")
 	}
 
+	CheckAndAddPeerToPeerP4Rules(s.p4rtbin)
+
 	if err := s.bridgeCtlr.AddPort(AccIntfNames[NF_IN_PR_INTF_INDEX]); err != nil {
 		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[NF_IN_PR_INTF_INDEX])
 		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[NF_IN_PR_INTF_INDEX])

--- a/p4sdk/Makefile
+++ b/p4sdk/Makefile
@@ -41,7 +41,7 @@ PLATFORMS ?= linux/arm64,linux/amd64
 imagex: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{TARGETPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{TARGETPLATFORM\}/' $(DOCKERFILE) > $(DOCKERFILE).cross
-	- $(IMGTOOL) buildx create --name image-builder-p4 --use --buildkitd-flags '--allow-insecure-entitlement security.insecure' --driver-opt env.http_proxy=$(HTTP_PROXY) --driver-opt env.https_proxy=$(HTTPS_PROXY) --driver-opt '"env.no_proxy='$(NO_PROXY)'"'
+	- $(IMGTOOL) buildx create --name image-builder-p4  --use --config=buildkit.toml --buildkitd-flags '--allow-insecure-entitlement security.insecure' --driver-opt env.http_proxy=$(HTTP_PROXY) --driver-opt env.https_proxy=$(HTTPS_PROXY) --driver-opt '"env.no_proxy='$(NO_PROXY)'"'
 	$(IMGTOOL) buildx use image-builder-p4
 	- $(IMGTOOL) buildx build --allow security.insecure --push --platform=$(PLATFORMS) --tag ${IMAGE_TAG_VERSION} -f $(DOCKERFILE).cross  $(CURDIR) $(DOCKERARGS)
 	- $(IMGTOOL) buildx rm image-builder-p4

--- a/p4sdk/buildkit.toml
+++ b/p4sdk/buildkit.toml
@@ -1,0 +1,2 @@
+[registry."localhost:5000"]
+  http = true


### PR DESCRIPTION
Changes to ensure that Peer2Peer P4 rules, will get added, independant, of order of deployment of VSP(ipu-plugin) on x86-host and ACC. If ipu-plugin's Init function gets invoked on ACC, prior to getting invoked on x86, then host VFs will not be setup yet. In that case, peer2peer rules can get added in CreateBridgePort or CreateNetworkFunction. Moved Deletion of P4 rules(such as PeerToPeer) at the point, where pod gets deleted, this increases the timeout period to greater than default 30 seconds, so updated vsp-ds.yaml file with increased timeout. And few misc fixes part of this PR.