### PR TITLE
Configure rx_phy_port_pr_map table's default action with D5's updated VSI ID

### DIFF
--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -716,6 +716,7 @@ PORT_SETUP_SCRIPT=/work/scripts/port-setup.sh
 POST_INIT_LOG=/work/scripts/post-init.log
 PORT_SETUP_LOG=/work/scripts/port-setup.log
 PORT_SETUP_LOG2=/work/scripts/port-setup2.log
+OPCODE_CFG_FILE=$(mktemp -p /tmp --suffix=.txt)
 
 /usr/bin/rm -f ${PORT_SETUP_SCRIPT} ${POST_INIT_LOG}
 /usr/bin/rm -f ${PORT_SETUP_LOG} ${POST_SETUP_LOG2}
@@ -779,6 +780,13 @@ if [ \${#cli_entry[@]} -gt 1 ] ; then
                   echo "RunDevMemCmds_Start: LogFile->"
                   # Critical section - only one script can be here at a time
                   set -x
+		  # OPCODE update to program the rx_phy_port_to_pr_map table default action with the correct vsi_id of D5 interface, which could potentially change
+		  # per reboot of IMC.
+		  # opcode 0x1305 is for DELETE an entry.
+                  echo "opcode=0x1305 prof_id=0xb cookie=123 key=0x00,0x00,0x00,0x00 act=set_vsi{act_val=\${vsi_id} val_type=0 dst_pe=0 slot=0x0}" > $OPCODE_CFG_FILE
+                  # opcode 0x1303 is for ADD an entry.
+		  echo "opcode=0x1303 prof_id=0xb cookie=123 key=0x00,0x00,0x00,0x00 act=set_vsi{act_val=\${vsi_id} val_type=0 dst_pe=0 slot=0x0}" >> $OPCODE_CFG_FILE
+		  cli_client -x -f $OPCODE_CFG_FILE
                   devmem 0x20292002a0 64 \${VSI_GROUP_INIT}
                   devmem 0x2029200388 64 0x1
                   devmem 0x20292002a0 64 \${VSI_GROUP_WRITE}
@@ -907,9 +915,9 @@ if [ -e %s ]; then
     sed -i 's/pf_mac_address = "00:00:00:00:03:14";/pf_mac_address = "%s";/g' $CP_INIT_CFG
     sed -i 's/acc_apf = 4;/acc_apf = %s;/g' $CP_INIT_CFG
     sed -i 's/comm_vports = .*/comm_vports = (([5,0],[4,0]),([0,3],[5,3]),([0,2],[4,3]));/g' $CP_INIT_CFG
-    sed -i 's/uplink_vports = .*/uplink_vports = ([0,0,0],[0,1,1],[4,1,0],[4,5,1],[5,1,0],[5,2,1]);/g' $CP_INIT_CFG
-    sed -i 's/rep_vports = .*/rep_vports = ([0,0,0],[4,5,1]);/g' $CP_INIT_CFG
-    sed -i 's/exception_vports = .*/exception_vports = ([0,0,0],[4,5,1]); /g' $CP_INIT_CFG
+    sed -i 's/uplink_vports = .*/uplink_vports = ([4,5,0],[5,1,0],[5,2,1]);/g' $CP_INIT_CFG
+    sed -i 's/rep_vports = .*/rep_vports = ([4,5,0]);/g' $CP_INIT_CFG
+    sed -i 's/exception_vports = .*/exception_vports = ([4,5,0]); /g' $CP_INIT_CFG
 else
     echo "No custom package found. Continuing with default package"
 fi


### PR DESCRIPTION
fxp-net_linux-networking P4 package has a predefined default action value which always forwards the packets to a fixed vsi_id, which is presumed to be the one assigned to the D5 interface. As the vsi_id assignments per inteface is dynamic (which can change per running instance), a change in D5's vsi_id could potentally break the D5 communication right after IPU init, where the P4 rules are still not programmed.

To address this issue, we update the rx_phy_port_pr_map table's default action with the correct vsi_id of D5 interface as part of the port init configuration procedures.