### PR TITLE
Support upto 16 Host VFs(pods), with increase of netdevs on ACC(to 48) 

### DIFF
--- a/ipu-plugin/pkg/ipuplugin/bridgeport.go
+++ b/ipu-plugin/pkg/ipuplugin/bridgeport.go
@@ -28,65 +28,86 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-const (
-	outerVlanId = 0 // hardcoded s-tag
-)
-
+/*
+interfaces slice will be populated with PortIds on ACC(port representators->PRs on ACC, for Host VFs),
+for example, if ACC interface name is enp0s1f0d4, PortId(vportId) will be 4.
+Will also include port representators->PRs needed for Network Functions.
+interfaces = {HOST_VF_START_ID(22) to HOST_VF_END_ID(37), NF_PR_START_ID(6) to NF_PR_END_ID(13)}
+intfMap is a map, that has key:value, between interfaceId and whether it is available(true or false) for use.
+*/
+var interfaces []uint
+var intfMap map[uint]bool
 var intfMapInit bool = false
 
-// Note: 3 reserved(last digit of interface name, for example, enp0s1f0d8, is 8) in exlude list in deviceplugin.
-var interfaces [3]string = [3]string{"6", "7", "8"}
-var intfMap map[string]bool
-
 func initMap() error {
-	if intfMapInit == false {
-		intfMap = make(map[string]bool)
+	var index uint
+	if !intfMapInit {
+		for index = HOST_VF_START_ID; index <= HOST_VF_END_ID; index = index + 1 {
+			interfaces = append(interfaces, index)
+		}
+		for index = NF_PR_START_ID; index <= NF_PR_END_ID; index = index + 1 {
+			interfaces = append(interfaces, index)
+		}
+		intfMap = make(map[uint]bool)
 		for _, intf := range interfaces {
 			intfMap[intf] = false
 		}
 		if len(interfaces) != len(intfMap) {
-			log.Errorf("initMap setup error\n")
-			return fmt.Errorf("initMap setup error\n")
+			log.Errorf("initMap setup error")
+			return fmt.Errorf("initMap setup error")
 		}
 		intfMapInit = true
 	}
 	return nil
 }
 
-// in-order(sorted by interface name->interfaces) allocation, based on available ACC interfaces(for Host VF)
-func allocateAccInterface() (error, string) {
-	var intfName string = ""
-	log.Debugf("allocateAccInterface\n")
-	if intfMapInit == false {
+// in-order(sorted by interface IDs) allocation. Based on available ACC interfaces(for Host VF
+// and NF PRs). Currently there are 2 ranges, first range(sorted) is for available Host-VF interface IDs
+// (HOST_VF_START_ID to HOST_VF_END_ID) and second range(sorted) for NF PRs(NF_PR_START_ID to NF_PR_END_ID)
+func AllocateAccInterface(allocPr string) (uint, error) {
+	var intfId uint = 0
+	start, end := 0, 0
+
+	found := false
+	log.Debugf("AllocateAccInterface\n")
+	if !intfMapInit {
 		initMap()
 	}
-	for _, key := range interfaces {
-		log.Debugf("intfName->%v\n", key)
+	if allocPr == types.HostVfPr {
+		start = 0
+		end = HOST_VF_END_ID - HOST_VF_START_ID
+	} else {
+		start = HOST_VF_END_ID - HOST_VF_START_ID + 1
+		end = start + NF_PR_END_ID - NF_PR_START_ID
+	}
+	for i := start; i <= end; i++ {
+		key := interfaces[i]
 		value, present := intfMap[key]
-		if present == true && value == false {
+		if present && !value {
 			log.Debugf("Found avail Intf->%v: \n", key)
 			intfMap[key] = true
-			intfName = key
+			intfId = key
+			found = true
 			break
 		}
 	}
-	if intfName != "" {
-		return nil, intfName
+	if found {
+		return intfId, nil
 	}
-	log.Errorf("Interface not available\n")
-	return fmt.Errorf("Interface not available\n"), intfName
+	log.Errorf("AllocateAccInterface: Interface not available")
+	return intfId, fmt.Errorf("AllocateAccInterface: interface not available")
 }
 
-func freeAccInterface(intfName string) error {
-	log.Debugf("freeAccInterface\n")
-	value, present := intfMap[intfName]
-	if present == true && value == true {
-		log.Debugf("Found allocated Intf->%v: \n", intfName)
-		intfMap[intfName] = false
+func FreeAccInterface(intfId uint) error {
+	log.Debugf("FreeAccInterface\n")
+	value, present := intfMap[intfId]
+	if present && value {
+		log.Debugf("Found allocated Intf->%v: \n", intfId)
+		intfMap[intfId] = false
 		return nil
 	}
-	log.Errorf("Interface->%s not found in freeAccInterface\n", intfName)
-	return fmt.Errorf("Interface->%s not found in freeAccInterface\n", intfName)
+	log.Errorf("Interface->%v not found in FreeAccInterface", intfId)
+	return fmt.Errorf("interface->%v not found in FreeAccInterface", intfId)
 }
 
 // CreateBridgePort executes the creation of the port
@@ -127,32 +148,26 @@ func (s *server) CreateBridgePort(_ context.Context, in *pb.CreateBridgePortRequ
 
 	CheckAndAddPeerToPeerP4Rules(s.p4rtClient)
 
-	err, intfName := allocateAccInterface()
+	intfId, err := AllocateAccInterface(types.HostVfPr)
 	if err != nil {
-		return nil, fmt.Errorf("error from allocateAccInterface->%v", err)
+		return nil, fmt.Errorf("error from AllocateAccInterface->%v", err)
 	}
 
-	intIndex, err := strconv.Atoi(string(intfName))
-	if err != nil {
-		log.Errorf("error->%v converting, intfName->%v", err, intfName)
-		return nil, fmt.Errorf("error->%v converting, intfName->%v", err, intfName)
-	} else {
-		log.Infof("intIndex->%v, fullIntfName->%v", intIndex, AccIntfNames[intIndex])
-	}
+	log.Infof("intfId->%v, fullIntfName->%v", intfId, AccApfInfo[intfId].Name)
 
-	if err := s.bridgeCtlr.AddPort(AccIntfNames[intIndex]); err != nil {
-		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[intIndex])
-		freeAccInterface(intfName)
-		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[intIndex])
+	if err := s.bridgeCtlr.AddPort(AccApfInfo[intfId].Name); err != nil {
+		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[intfId].Name)
+		FreeAccInterface(intfId)
+		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[intfId].Name)
 	}
 
 	// Add FXP rules
-	log.Infof("AddHostVfP4Rules, path->%s, 1->%v, 2->%v", s.p4rtClient.GetBin(), in.BridgePort.Spec.MacAddress, AccApfMacList[intIndex])
-	p4rtclient.AddHostVfP4Rules(s.p4rtClient, in.BridgePort.Spec.MacAddress, AccApfMacList[intIndex])
+	log.Infof("AddHostVfP4Rules, path->%s, 1->%v, 2->%v", s.p4rtClient.GetBin(), in.BridgePort.Spec.MacAddress, AccApfInfo[intfId].Mac)
+	p4rtclient.AddHostVfP4Rules(s.p4rtClient, in.BridgePort.Spec.MacAddress, AccApfInfo[intfId].Mac)
 
 	resp := proto.Clone(in.BridgePort).(*pb.BridgePort)
 	resp.Status = &pb.BridgePortStatus{OperStatus: pb.BPOperStatus_BP_OPER_STATUS_UP}
-	pbBridgePortInfo := &types.BridgePortInfo{PbBrPort: resp, PortInterface: intfName}
+	pbBridgePortInfo := &types.BridgePortInfo{PbBrPort: resp, PortId: intfId}
 	s.Ports[in.BridgePort.Name] = pbBridgePortInfo
 	return resp, nil
 }
@@ -180,22 +195,17 @@ func (s *server) DeleteBridgePort(_ context.Context, in *pb.DeleteBridgePortRequ
 	}
 	portInfo = brPortInfo.PbBrPort
 
-	intIndex, err := strconv.Atoi(string(brPortInfo.PortInterface))
-	if err != nil {
-		log.Errorf("error->%v converting, intfName->%v", err, brPortInfo.PortInterface)
-		return nil, fmt.Errorf("error->%v converting, intfName->%v", err, brPortInfo.PortInterface)
-	} else {
-		log.Infof("intIndex->%v, fullIntfName->%v", intIndex, AccIntfNames[intIndex])
-	}
+	intfId := brPortInfo.PortId
+	log.Infof("intfIndex->%v, fullIntfName->%v", intfId, AccApfInfo[intfId].Name)
 
-	if err := s.bridgeCtlr.DeletePort(AccIntfNames[intIndex]); err != nil {
-		log.Errorf("unable to delete port from bridge: %v, for interface->%v", err, AccIntfNames[intIndex])
-		return nil, fmt.Errorf("unable to delete port from bridge: %v, for interface->%v", err, AccIntfNames[intIndex])
+	if err := s.bridgeCtlr.DeletePort(AccApfInfo[intfId].Name); err != nil {
+		log.Errorf("unable to delete port from bridge: %v, for interface->%v", err, AccApfInfo[intfId].Name)
+		return nil, fmt.Errorf("unable to delete port from bridge: %v, for interface->%v", err, AccApfInfo[intfId].Name)
 	}
-	freeAccInterface(brPortInfo.PortInterface)
+	FreeAccInterface(brPortInfo.PortId)
 	// Delete FXP rules
-	log.Infof("DeleteHostVfP4Rules, path->%s, 1->%v, 2->%v", s.p4rtClient.GetBin(), portInfo.Spec.MacAddress, AccApfMacList[intIndex])
-	p4rtclient.DeleteHostVfP4Rules(s.p4rtClient, portInfo.Spec.MacAddress, AccApfMacList[intIndex])
+	log.Infof("DeleteHostVfP4Rules, path->%s, 1->%v, 2->%v", s.p4rtClient.GetBin(), portInfo.Spec.MacAddress, AccApfInfo[intfId].Mac)
+	p4rtclient.DeleteHostVfP4Rules(s.p4rtClient, portInfo.Spec.MacAddress, AccApfInfo[intfId].Mac)
 
 	delete(s.Ports, in.Name)
 	return &emptypb.Empty{}, nil

--- a/ipu-plugin/pkg/ipuplugin/bridgeport_test.go
+++ b/ipu-plugin/pkg/ipuplugin/bridgeport_test.go
@@ -107,7 +107,7 @@ var _ = Describe("bridgeport", Serial, func() {
 					},
 				}
 				fakePortBridgeInfo := &types.BridgePortInfo{
-					fakePort, "fakePort1",
+					fakePort, 10,
 				}
 
 				fakeReq := &pb.CreateBridgePortRequest{BridgePort: fakePort}
@@ -131,7 +131,7 @@ var _ = Describe("bridgeport", Serial, func() {
 					},
 				}
 				fakePortBridgeInfo := &types.BridgePortInfo{
-					fakePort, "fakePort1",
+					fakePort, 10,
 				}
 				ipuServer.Ports["fakePort"] = fakePortBridgeInfo // fakePort already exists in internal Map
 

--- a/ipu-plugin/pkg/ipuplugin/bridgeport_test.go
+++ b/ipu-plugin/pkg/ipuplugin/bridgeport_test.go
@@ -65,21 +65,6 @@ var _ = Describe("bridgeport", Serial, func() {
 				Expect(err).To(HaveOccurred())
 			})
 		})
-		Context("when no vlan id is not in valid vlan range", func() {
-			It("should return error", func() {
-				fakeMacAddr := []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
-				fakeReq := &pb.CreateBridgePortRequest{
-					BridgePort: &pb.BridgePort{
-						Spec: &pb.BridgePortSpec{
-							MacAddress:     fakeMacAddr,
-							LogicalBridges: []string{"0"},
-						},
-					},
-				}
-				_, err := ipuServer.CreateBridgePort(context.TODO(), fakeReq)
-				Expect(err).To(HaveOccurred())
-			})
-		})
 		Context("when no VF VSI is 0", func() {
 			It("should return error", func() {
 				fakeMacAddr := []byte{0xaa, 0x00, 0xcc, 0xdd, 0xee, 0xff} // the second octet here is the VSI number

--- a/ipu-plugin/pkg/ipuplugin/deviceplugin.go
+++ b/ipu-plugin/pkg/ipuplugin/deviceplugin.go
@@ -23,10 +23,6 @@ type DevicePluginService struct {
 }
 
 var (
-	//TODO: Use (GetFilteredPfs), to find interface names to be excluded.
-	//excluding d3(host-acc), reserving D4-D5(QSPF ports) D6-D8(for max 3 host VFs), D9-D10(for single NF)
-	exclude = []string{"enp0s1f0", "enp0s1f0d1", "enp0s1f0d2", "enp0s1f0d3", "enp0s1f0d4", "enp0s1f0d5", "enp0s1f0d6",
-		"enp0s1f0d7", "enp0s1f0d8", "enp0s1f0d9", "enp0s1f0d10"}
 	sysClassNet      = "/sys/class/net"
 	sysBusPciDevices = "/sys/bus/pci/devices"
 	deviceCode       = "0x1452"
@@ -266,6 +262,15 @@ func discoverHostDevices(mode string) (map[string]*pb.Device, error) {
 	if mode != types.IpuMode && mode != types.HostMode {
 		return make(map[string]*pb.Device), fmt.Errorf("Invalid mode->%v", mode)
 	}
+	//Note: It is expected that VSP's-Init(on ACC) gets invoked prior to GetDevices,
+	//this check is meant to catch any anomalies.
+	if mode == types.IpuMode {
+		if len(AccApfsAvailForCNI) == 0 {
+			log.Errorf("discoverHostDevices: Error, AccApfsAvailForCNI not setup")
+			return make(map[string]*pb.Device), fmt.Errorf("discoverHostDevices: Error, AccApfsAvailForCNI not setup")
+		}
+	}
+
 	if mode == types.IpuMode {
 		if accDevs == nil {
 			accDevs = make(map[string]*pb.Device)
@@ -296,7 +301,7 @@ func discoverHostDevices(mode string) (map[string]*pb.Device, error) {
 		device_code := strings.TrimSpace(string(deviceCodeByte))
 		if mode == types.IpuMode {
 			if device_code == deviceCode {
-				if !slices.Contains(exclude, file.Name()) {
+				if slices.Contains(AccApfsAvailForCNI, file.Name()) {
 					accDevs[file.Name()] = &pb.Device{ID: file.Name(), Health: pluginapi.Healthy}
 				}
 			}

--- a/ipu-plugin/pkg/ipuplugin/ipuplugin.go
+++ b/ipu-plugin/pkg/ipuplugin/ipuplugin.go
@@ -228,8 +228,8 @@ func (s *server) Run() error {
 }
 
 func cleanUpRulesOnExit(p4rtClient types.P4RTClient) error {
-	log.Infof("DeletePhyPortRules, path->%s, 1->%v, 2->%v", p4rtClient.GetBin(), AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
-	p4rtclient.DeletePhyPortRules(p4rtClient, AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
+	log.Infof("DeletePhyPortRules, path->%s, 1->%v, 2->%v", p4rtClient.GetBin(), AccApfInfo[PHY_PORT0_INTF_INDEX].Mac, AccApfInfo[PHY_PORT1_INTF_INDEX].Mac)
+	p4rtclient.DeletePhyPortRules(p4rtClient, AccApfInfo[PHY_PORT0_INTF_INDEX].Mac, AccApfInfo[PHY_PORT1_INTF_INDEX].Mac)
 
 	vfMacList, err := utils.GetVfMacList()
 	if err != nil {
@@ -246,8 +246,8 @@ func cleanUpRulesOnExit(p4rtClient types.P4RTClient) error {
 	log.Infof("DeleteLAGP4Rules, path->%s", p4rtClient.GetBin())
 	p4rtclient.DeleteLAGP4Rules(p4rtClient)
 
-	log.Infof("DeleteRHPrimaryNetworkVportP4Rules, path->%s, 1->%v", p4rtClient, AccApfMacList[PHY_PORT1_INTF_INDEX])
-	p4rtclient.DeleteRHPrimaryNetworkVportP4Rules(p4rtClient, AccApfMacList[PHY_PORT1_INTF_INDEX])
+	log.Infof("DeleteRHPrimaryNetworkVportP4Rules, path->%s, 1->%v", p4rtClient, AccApfInfo[PHY_PORT1_INTF_INDEX].Mac)
+	p4rtclient.DeleteRHPrimaryNetworkVportP4Rules(p4rtClient, AccApfInfo[PHY_PORT1_INTF_INDEX].Mac)
 	return nil
 }
 

--- a/ipu-plugin/pkg/ipuplugin/ipuplugin.go
+++ b/ipu-plugin/pkg/ipuplugin/ipuplugin.go
@@ -253,6 +253,7 @@ func cleanUpRulesOnExit(p4rtClient types.P4RTClient) error {
 
 func (s *server) Stop() {
 	s.log.Info("Stopping IPU plugin")
+
 	if s.mode == types.IpuMode {
 		//Note: Deletes bridge created in EnsureBridgeExists in  Run api.
 		s.bridgeCtlr.DeleteBridges()

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	kh "golang.org/x/crypto/ssh/knownhosts"
+
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/p4rtclient"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/types"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/utils"

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	kh "golang.org/x/crypto/ssh/knownhosts"
+
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/p4rtclient"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/types"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/utils"
@@ -54,25 +56,42 @@ const (
 	deviceId            = "0x1452"
 	vendorId            = "0x8086"
 	imcAddress          = "192.168.0.1:22"
-	ApfNumber           = 16
+	ApfNumber           = 48
 	last_byte_mac_range = 239
 )
 
+type AccApfInfoType struct {
+	Mac  string
+	Name string
+}
+
+var AccApfInfo []AccApfInfoType
+var AccApfsAvailForCNI []string
+
 var InitAccApfMacs = false
-var AccApfMacList []string
 var PeerToPeerP4RulesAdded = false
 
-// Reserved ACC interfaces(using vport_id or last digit of interface name, like 4 represents-> enp0s1f0d4)
+// Reserved ACC interfaces(using vport_id or last digit of interface name, for example, index 4 represents-> enp0s1f0d4)
+/*
+NF_PR_START_ID->6 to NF_PR_END_ID->13
+NF_AVAIL_START_ID->14 to NF_AVAIL_END_ID->21
+HOST_VF_START_ID->22 to HOST_VF_END_ID->37
+*/
 const (
-	PHY_PORT0_INTF_INDEX = 4
-	PHY_PORT1_INTF_INDEX = 5
-	NF_IN_PR_INTF_INDEX  = 9
-	NF_OUT_PR_INTF_INDEX = 10
+	START_ID             = 0
+	RSVD_INIT_LEN        = 4
+	PHY_PORT0_INTF_INDEX = (START_ID + RSVD_INIT_LEN)
+	PHY_PORT1_INTF_INDEX = (PHY_PORT0_INTF_INDEX + 1)
+	MAX_NF_CNT           = 4
+	NF_PR_START_ID       = (PHY_PORT1_INTF_INDEX + 1)
+	NF_PR_LEN            = (MAX_NF_CNT * 2)
+	NF_PR_END_ID         = (NF_PR_START_ID + NF_PR_LEN - 1)
+	NF_AVAIL_START_ID    = NF_PR_END_ID + 1
+	NF_AVAIL_END_ID      = (NF_AVAIL_START_ID + NF_PR_LEN - 1)
+	HOST_VF_START_ID     = (NF_AVAIL_END_ID + 1)
+	MAX_HOST_VF_CNT      = (16)
+	HOST_VF_END_ID       = (HOST_VF_START_ID + MAX_HOST_VF_CNT - 1)
 )
-
-// TODO: GetFilteredPFs can be used to fill the array.
-var AccIntfNames = [ApfNumber]string{"enp0s1f0", "enp0s1f0d1", "enp0s1f0d2", "enp0s1f0d3", "enp0s1f0d4", "enp0s1f0d5", "enp0s1f0d6",
-	"enp0s1f0d7", "enp0s1f0d8", "enp0s1f0d9", "enp0s1f0d10", "enp0s1f0d11", "enp0s1f0d12", "enp0s1f0d13", "enp0s1f0d14", "enp0s1f0d15"}
 
 func NewLifeCycleService(daemonHostIp, daemonIpuIp string, daemonPort int, mode string, p4rtClient types.P4RTClient, brCtlr types.BridgeController) *LifeCycleServiceServer {
 	return &LifeCycleServiceServer{
@@ -121,6 +140,7 @@ type ExecutableHandler interface {
 	validate() bool
 	nmcliSetupIpAddress(link netlink.Link, ipStr string, ipAddr *netlink.Addr) error
 	SetupAccApfs() error
+	AddAccApfsToGroupOne() error
 }
 
 type ExecutableHandlerImpl struct{}
@@ -965,12 +985,120 @@ func skipIMCReboot() (bool, string) {
 
 }
 
-func (e *ExecutableHandlerImpl) validate() bool {
+// this api queries the param->acc_apf in /etc/dpcp/cp_init.cfg.
+// The param(acc_apf) appears in 3 lines in that file, and we run
+// the command to fetch the value in the second line.
+func queryNumAccApfsInIMCConfig() (int, error) {
 
-	if numAPFs := countAPFDevices(); numAPFs < ApfNumber {
-		log.Errorf("Not enough APFs %v, expected->%v", numAPFs, ApfNumber)
+	log.Infof("queryNumAccApfsInIMCConfig")
+	//remove duplicate entries, and ensure host-key(ssh-keyscan) is present.
+	sshCmds := "ssh-keygen -R 192.168.0.1; ssh-keyscan 192.168.0.1 >> /root/.ssh/known_hosts"
+
+	_, err := utils.ExecuteScript(sshCmds)
+	if err != nil {
+		log.Errorf("error->%v, for ssh key commands->%v", err, sshCmds)
+		return 0, fmt.Errorf("error->%v, for ssh key commands->%v", err, sshCmds)
+	}
+
+	hostKeyCallback, err := kh.New("/root/.ssh/known_hosts")
+	if err != nil {
+		log.Errorf("error->%v, unable to create hostkeycallback function: ", err)
+		return 0, fmt.Errorf("error->%v, unable to create hostkeycallback function: ", err)
+	}
+
+	config := &ssh.ClientConfig{
+		User: "root",
+		Auth: []ssh.AuthMethod{
+			ssh.Password(""),
+		},
+		HostKeyCallback: hostKeyCallback,
+	}
+
+	// Connect to the remote server.
+	client, err := ssh.Dial("tcp", imcAddress, config)
+	if err != nil {
+		return 0, fmt.Errorf("failed to dial remote server: %s", err)
+	}
+	defer client.Close()
+
+	// Start a session.
+	session, err := client.NewSession()
+	if err != nil {
+		return 0, fmt.Errorf("failed to create session: %s", err)
+	}
+	defer session.Close()
+
+	commands := `grep "acc_apf = "  /etc/dpcp/cp_init.cfg | sed -n 2p | awk '/acc_apf = / {print $3}'`
+
+	// Run a command on the remote server and capture the output.
+	outputBytes, err := session.CombinedOutput(commands)
+	if err != nil {
+		log.Errorf("queryNumAccApfsInIMCConfig: error from command->%v", err)
+		return 0, fmt.Errorf("queryNumAccApfsInIMCConfig: error from command->%v", err)
+	}
+
+	outputStr := strings.TrimSuffix(string(outputBytes), "\n")
+	//to skip the semicolon, for example, if output is-> 48;
+	outputStr = outputStr[:len(outputStr)-1]
+
+	numAccApfs, err := strconv.Atoi(outputStr)
+
+	if err != nil {
+		log.Errorf("queryNumAccApfsInIMCConfig: Error converting string to int: %v", err)
+		return 0, fmt.Errorf("queryNumAccApfsInIMCConfig: Error converting string to int: %v", err)
+	}
+	log.Infof("queryNumAccApfsInIMCConfig ->%v", numAccApfs)
+
+	return numAccApfs, nil
+
+}
+
+// wait for the expected number of ACC APFs to get initialized.
+// Per testing, after kernel boots, it takes around 40 secs for 48 APFs
+// to get initialized. This api waits for 1 sec per APF.
+func waitForAccApfsInit() error {
+	maxRetries := ApfNumber
+	retryInterval := time.Second
+
+	var count int
+	for count = 0; count < maxRetries; count++ {
+		time.Sleep(retryInterval)
+		log.Infof("waitForAccApfsInit: retry count:%d", count)
+		numApfs := countAPFDevices()
+		if numApfs < ApfNumber {
+			log.Warnf("numApfs->%v, less than expected-> %v", numApfs, ApfNumber)
+			continue
+		} else if numApfs == ApfNumber {
+			log.Infof("expected numApfs->%v initialized", numApfs)
+			break
+		}
+	}
+	if count == maxRetries {
+		log.Fatalf("Failed to wait for ACC APFs to get initialized. Exiting\n")
+		os.Exit(1)
+	}
+	return nil
+}
+
+func (e *ExecutableHandlerImpl) validate() bool {
+	//TODO: Do we really need queryNumAccApfsInIMCConfig,
+	//instead we could just let waitForAccApfsInit determine it.
+	/*numAccApfs, err := queryNumAccApfsInIMCConfig()
+
+	if err != nil {
+		log.Errorf("Error->%v, from queryNumAccApfsInIMCConfig", err)
 		return false
 	}
+
+	if numAccApfs != ApfNumber {
+		log.Errorf("Not enough APFs %v, expected->%v", numAccApfs, ApfNumber)
+		return false
+	}*/
+
+	if err := waitForAccApfsInit(); err != nil {
+		return false
+	}
+
 	if noReboot, infoStr := skipIMCReboot(); !noReboot {
 		fmt.Printf("IMC reboot required : %v\n", infoStr)
 		return false
@@ -980,25 +1108,93 @@ func (e *ExecutableHandlerImpl) validate() bool {
 }
 
 func (e *ExecutableHandlerImpl) SetupAccApfs() error {
-	var err error
-
 	if !InitAccApfMacs {
-		AccApfMacList, err = utils.GetAccApfMacList()
+		var pfList []netlink.Link
+		InitHandlers()
+		if err := GetFilteredPFs(&pfList); err != nil {
+			log.Errorf("SetupAccApfs: err->%v from GetFilteredPFs", err)
+			return fmt.Errorf("SetupAccApfs: err->%v from GetFilteredPFs", err)
+		}
+		if len(pfList) != ApfNumber {
+			log.Errorf("not enough APFs initialized on ACC, total APFs->%d, APFs->%v", len(pfList), pfList)
+			return fmt.Errorf("not enough APFs initialized on ACC, total APFs->%d, APFs->%v", len(pfList), pfList)
+		}
 
+		for i := 0; i < len(pfList); i++ {
+			accApf := AccApfInfoType{
+				Mac:  pfList[i].Attrs().HardwareAddr.String(),
+				Name: pfList[i].Attrs().Name,
+			}
+			AccApfInfo = append(AccApfInfo, accApf)
+		}
+	}
+	log.Infof("AccApfInfo->%v", AccApfInfo)
+	for i := NF_AVAIL_START_ID; i <= NF_AVAIL_END_ID; i = i + 1 {
+		AccApfsAvailForCNI = append(AccApfsAvailForCNI, AccApfInfo[i].Name)
+	}
+	log.Infof("AccApfsAvailForCNI->%v", AccApfsAvailForCNI)
+
+	InitAccApfMacs = true
+	return nil
+}
+
+func (e *ExecutableHandlerImpl) AddAccApfsToGroupOne() error {
+	vsiList, err := utils.GetAvailableAccVsiList()
+	if err != nil {
+		log.Errorf("AddAccApfsToGroupOne: unable to reach the IMC %v", err)
+		return fmt.Errorf("AddAccApfsToGroupOne: unable to reach the IMC %v", err)
+	}
+	if len(vsiList) == 0 {
+		log.Errorf("no APFs initialized on ACC")
+		return fmt.Errorf("no APFs initialized on ACC")
+	}
+	log.Infof("AddAccApfsToGroupOne, vsiList->%v", vsiList)
+	/*  Steps from script(for reference)
+	VSI_GROUP_INIT=$(printf  "0x%x" $((0x8000050000000000 + IDPF_VPORT_VSI_HEX)))
+	VSI_GROUP_WRITE=$(printf "0x%x" $((0xA000050000000000 + IDPF_VPORT_VSI_HEX)))
+	devmem 0x20292002a0 64 ${VSI_GROUP_INIT}
+	devmem 0x2029200388 64 0x1
+	devmem 0x20292002a0 64 ${VSI_GROUP_WRITE}
+	*/
+	for i := 0; i < len(vsiList); i++ {
+		log.Infof("Add to VSI Group 1, vsi->%v", vsiList[i])
+		hexStr := vsiList[i]
+		// skip "0x" prefix
+		hexStr = hexStr[2:]
+
+		// Convert to hex value
+		hexVal, err := strconv.ParseInt(hexStr, 16, 64)
 		if err != nil {
-			log.Errorf("SetupAccApfs: Error-> %v", err)
-			return fmt.Errorf("SetupAccApfs: Error-> %v", err)
+			log.Errorf("error decoding hex: %v", err)
+			return fmt.Errorf("error decoding hex: %v", err)
 		}
 
-		if len(AccApfMacList) != ApfNumber {
-			log.Errorf("not enough APFs initialized on ACC, total APFs->%d, APFs->%v", len(AccApfMacList), AccApfMacList)
-			return fmt.Errorf("not enough APFs initialized on ACC, total APFs->%d", len(AccApfMacList))
+		// Check bounds before converting to uint64
+		if hexVal < 0 {
+			log.Errorf("hex value out of range: %v", hexVal)
+			return fmt.Errorf("hex value out of range: %v", hexVal)
 		}
-		log.Infof("On ACC, total APFs->%d", len(AccApfMacList))
-		for i := 0; i < len(AccApfMacList); i++ {
-			log.Infof("index->%d, mac->%s", i, AccApfMacList[i])
+
+		var vsiGroupInit, vsiGroupWrite uint64
+
+		vsiGroupInit = 0x8000050000000000 + uint64(hexVal)
+		vsiGroupWrite = 0xA000050000000000 + uint64(hexVal)
+
+		vsiGroupInitString := fmt.Sprintf("0x%X", vsiGroupInit)
+		vsiGroupWriteString := fmt.Sprintf("0x%X", vsiGroupWrite)
+
+		devMemCmd1 := "devmem 0x20292002a0 64 " + vsiGroupInitString
+		devMemCmd2 := "devmem 0x2029200388 64 0x1"
+		devMemCmd3 := "devmem 0x20292002a0 64 " + vsiGroupWriteString
+
+		devMemCmd := devMemCmd1 + "; " + devMemCmd2 + "; " + devMemCmd3 + "; "
+		log.Infof("devMemCmd->%v", devMemCmd)
+
+		_, err = utils.ExecuteScript(fmt.Sprintf(`ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 root@192.168.0.1 "%s"`, devMemCmd))
+		if err != nil {
+			log.Errorf("err exec devMemCmd->%v", err)
+			return fmt.Errorf("err exec devMemCmd->%v", err)
 		}
-		InitAccApfMacs = true
 	}
 	return nil
 }
@@ -1030,13 +1226,13 @@ func (s *FXPHandlerImpl) configureFXP(p types.P4RTClient, brCtlr types.BridgeCon
 	}
 	//Add Phy Port0 to ovs bridge
 	//Note: Per current design, Phy Port1 is added to a different bridge(through P4 rules).
-	if err := brCtlr.AddPort(AccIntfNames[PHY_PORT0_INTF_INDEX]); err != nil {
-		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[PHY_PORT0_INTF_INDEX])
-		return fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[PHY_PORT0_INTF_INDEX])
+	if err := brCtlr.AddPort(AccApfInfo[PHY_PORT0_INTF_INDEX].Name); err != nil {
+		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[PHY_PORT0_INTF_INDEX].Name)
+		return fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[PHY_PORT0_INTF_INDEX].Name)
 	}
 	//Add P4 rules for phy ports
-	log.Infof("AddPhyPortRules, path->%s, 1->%v, 2->%v", p.GetBin(), AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
-	p4rtclient.AddPhyPortRules(p, AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
+	log.Infof("AddPhyPortRules, path->%s, 1->%v, 2->%v", p.GetBin(), AccApfInfo[PHY_PORT0_INTF_INDEX].Mac, AccApfInfo[PHY_PORT1_INTF_INDEX].Mac)
+	p4rtclient.AddPhyPortRules(p, AccApfInfo[PHY_PORT0_INTF_INDEX].Mac, AccApfInfo[PHY_PORT1_INTF_INDEX].Mac)
 
 	CheckAndAddPeerToPeerP4Rules(p)
 
@@ -1052,8 +1248,8 @@ func (s *FXPHandlerImpl) configureFXP(p types.P4RTClient, brCtlr types.BridgeCon
 	time.Sleep(2 * time.Second)
 
 	//Add P4 rules to handle Primary network traffic via phy port0
-	log.Infof("AddRHPrimaryNetworkVportP4Rules,  path->%s, 1->%v, 2->%v", p.GetBin(), AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
-	p4rtclient.AddRHPrimaryNetworkVportP4Rules(p, AccApfMacList[PHY_PORT0_INTF_INDEX], AccApfMacList[PHY_PORT1_INTF_INDEX])
+	log.Infof("AddRHPrimaryNetworkVportP4Rules,  path->%s, 1->%v, 2->%v", p.GetBin(), AccApfInfo[PHY_PORT0_INTF_INDEX].Mac, AccApfInfo[PHY_PORT1_INTF_INDEX].Mac)
+	p4rtclient.AddRHPrimaryNetworkVportP4Rules(p, AccApfInfo[PHY_PORT0_INTF_INDEX].Mac, AccApfInfo[PHY_PORT1_INTF_INDEX].Mac)
 
 	return nil
 }
@@ -1078,6 +1274,10 @@ func (s *LifeCycleServiceServer) Init(ctx context.Context, in *pb.InitRequest) (
 			}
 		} else {
 			log.Info("not forcing state")
+		}
+		if err := ExecutableHandlerGlobal.AddAccApfsToGroupOne(); err != nil {
+			log.Fatalf("error from->AddAccApfsToGroupOne: %v", err)
+			return nil, fmt.Errorf("error from->AddAccApfsToGroupOne: %v", err)
 		}
 		if err := ExecutableHandlerGlobal.SetupAccApfs(); err != nil {
 			log.Errorf("error from  SetupAccApfs %v", err)

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -72,17 +72,17 @@ var InitAccApfMacs = false
 var PeerToPeerP4RulesAdded = false
 
 // Reserved ACC interfaces(using vport_id or last digit of interface name, for example, index 4 represents-> enp0s1f0d4)
-/*
-NF_PR_START_ID->6 to NF_PR_END_ID->13
-NF_AVAIL_START_ID->14 to NF_AVAIL_END_ID->21
-HOST_VF_START_ID->22 to HOST_VF_END_ID->37
+/* With 1 NF config
+NF_PR_START_ID->6 to NF_PR_END_ID->7
+NF_AVAIL_START_ID->8 to NF_AVAIL_END_ID->9
+HOST_VF_START_ID->10 to HOST_VF_END_ID->25
 */
 const (
 	START_ID             = 0
 	RSVD_INIT_LEN        = 4
 	PHY_PORT0_INTF_INDEX = (START_ID + RSVD_INIT_LEN)
 	PHY_PORT1_INTF_INDEX = (PHY_PORT0_INTF_INDEX + 1)
-	MAX_NF_CNT           = 4
+	MAX_NF_CNT           = 1
 	NF_PR_START_ID       = (PHY_PORT1_INTF_INDEX + 1)
 	NF_PR_LEN            = (MAX_NF_CNT * 2)
 	NF_PR_END_ID         = (NF_PR_START_ID + NF_PR_LEN - 1)

--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice_test.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice_test.go
@@ -264,6 +264,10 @@ func (m *MockExecutableHandlerImpl) SetupAccApfs() error {
 	return nil
 }
 
+func (m *MockExecutableHandlerImpl) AddAccApfsToGroupOne() error {
+	return nil
+}
+
 func (e *MockExecutableHandlerImpl) nmcliSetupIpAddress(link netlink.Link, ipStr string, ipAddr *netlink.Addr) error {
 	return fmt.Errorf("Method added for test purposes")
 }

--- a/ipu-plugin/pkg/ipuplugin/networkfunctionservice.go
+++ b/ipu-plugin/pkg/ipuplugin/networkfunctionservice.go
@@ -16,6 +16,8 @@ package ipuplugin
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/p4rtclient"
@@ -27,11 +29,16 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const (
+	PRS_LEN = 2
+)
+
 type NetworkFunctionServiceServer struct {
 	pb.UnimplementedNetworkFunctionServiceServer
 	Ports      map[string]*types.BridgePortInfo
 	bridgeCtlr types.BridgeController
 	p4rtClient types.P4RTClient
+	nfReqMap   map[string][PRS_LEN]uint
 }
 
 func NewNetworkFunctionService(ports map[string]*types.BridgePortInfo, brCtlr types.BridgeController, p4Client types.P4RTClient) *NetworkFunctionServiceServer {
@@ -39,7 +46,42 @@ func NewNetworkFunctionService(ports map[string]*types.BridgePortInfo, brCtlr ty
 		Ports:      ports,
 		bridgeCtlr: brCtlr,
 		p4rtClient: p4Client,
+		nfReqMap:   make(map[string][PRS_LEN]uint),
 	}
+}
+
+func AllocateAccInterfaceForNF() ([PRS_LEN]uint, error) {
+	var intfIds [PRS_LEN]uint
+
+	log.Debugf("AllocateAccInterfaceForNF\n")
+	for i := 0; i < PRS_LEN; i++ {
+		intfId, err := AllocateAccInterface(types.NfPr)
+		if err != nil {
+			return intfIds, fmt.Errorf("error from AllocateAccInterface->%v", err)
+		}
+		intfIds[i] = intfId
+	}
+	log.Infof("AllocateAccInterfaceForNF: Interfaces allocated->%v\n", intfIds)
+	return intfIds, nil
+}
+
+func FreeAccInterfaceForNF(intfIds [PRS_LEN]uint) error {
+
+	log.Debugf("FreeAccInterfaceForNF, intfIds->%v\n", intfIds)
+	for i := 0; i < PRS_LEN; i++ {
+		err := FreeAccInterface(intfIds[i])
+		if err != nil {
+			log.Errorf("error from AllocateAccInterface->%v", err)
+		}
+	}
+	return nil
+}
+
+func deriveKey(in *pb.NFRequest) string {
+	nfReqHash := md5.Sum([]byte(in.Input + in.Output))
+	nfReqHashStr := hex.EncodeToString(nfReqHash[:])
+	log.Infof("deriveKey->%s", nfReqHashStr)
+	return nfReqHashStr
 }
 
 func (s *NetworkFunctionServiceServer) CreateNetworkFunction(ctx context.Context, in *pb.NFRequest) (*pb.Empty, error) {
@@ -51,21 +93,33 @@ func (s *NetworkFunctionServiceServer) CreateNetworkFunction(ctx context.Context
 
 	CheckAndAddPeerToPeerP4Rules(s.p4rtClient)
 
-	if err := s.bridgeCtlr.AddPort(AccIntfNames[NF_IN_PR_INTF_INDEX]); err != nil {
-		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[NF_IN_PR_INTF_INDEX])
-		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[NF_IN_PR_INTF_INDEX])
+	intfIds, err := AllocateAccInterfaceForNF()
+	if err != nil {
+		log.Errorf("error from AllocateAccInterfaceForNF: %v, intfIds->%v", err, intfIds)
+		return nil, fmt.Errorf("error from AllocateAccInterfaceForNF: %v, intfIds->%v", err, intfIds)
 	}
-	if err := s.bridgeCtlr.AddPort(AccIntfNames[NF_OUT_PR_INTF_INDEX]); err != nil {
-		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[NF_OUT_PR_INTF_INDEX])
-		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[NF_OUT_PR_INTF_INDEX])
+	NF_IN_PR := intfIds[0]
+	NF_OUT_PR := intfIds[1]
+	log.Infof("CNF: allocated NF PRs index (IN)->%v, OUT->%v", NF_IN_PR, NF_OUT_PR)
+
+	if err := s.bridgeCtlr.AddPort(AccApfInfo[NF_IN_PR].Name); err != nil {
+		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[NF_IN_PR].Name)
+		FreeAccInterfaceForNF(intfIds)
+		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[NF_IN_PR].Name)
 	}
-	log.Infof("added interfaces:inPR->%s, outPR->%s", AccIntfNames[NF_IN_PR_INTF_INDEX], AccIntfNames[NF_OUT_PR_INTF_INDEX])
+	if err := s.bridgeCtlr.AddPort(AccApfInfo[NF_OUT_PR].Name); err != nil {
+		log.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[NF_OUT_PR].Name)
+		FreeAccInterfaceForNF(intfIds)
+		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[NF_OUT_PR].Name)
+	}
+	log.Infof("added interfaces:inPR->%s, outPR->%s", AccApfInfo[NF_IN_PR].Name, AccApfInfo[NF_OUT_PR].Name)
 	/*Note: Currently this API does not have host-VF info, since there is no reference to what was passed by DPU in CreateBridgePort.
 	As a work-around, we take full vfMacList, and write P4 rules, to connect all host VFs to NF.	*/
 	// Generate the P4 rules and program the FXP with NF comms
 	log.Infof("AddNFP4Rules, path->%s, 1-%v, 2-%v, 3-%v, 4-%v, 5-%v",
-		s.p4rtClient.GetBin(), vfMacList, in.Input, in.Output, AccApfMacList[NF_IN_PR_INTF_INDEX], AccApfMacList[NF_OUT_PR_INTF_INDEX])
-	p4rtclient.AddNFP4Rules(s.p4rtClient, vfMacList, in.Input, in.Output, AccApfMacList[NF_IN_PR_INTF_INDEX], AccApfMacList[NF_OUT_PR_INTF_INDEX])
+		s.p4rtClient.GetBin(), vfMacList, in.Input, in.Output, AccApfInfo[NF_IN_PR].Mac, AccApfInfo[NF_OUT_PR].Mac)
+	p4rtclient.AddNFP4Rules(s.p4rtClient, vfMacList, in.Input, in.Output, AccApfInfo[NF_IN_PR].Mac, AccApfInfo[NF_OUT_PR].Mac)
+	s.nfReqMap[deriveKey(in)] = intfIds
 
 	return &pb.Empty{}, nil
 }
@@ -78,20 +132,34 @@ func (s *NetworkFunctionServiceServer) DeleteNetworkFunction(ctx context.Context
 		log.Errorf("DeleteNetworkFunction: Error-> %v", err)
 		return nil, status.Errorf(codes.Internal, "Error-> %v", err)
 	}
+	mapKey := deriveKey(in)
+	intfIds, ok := s.nfReqMap[mapKey]
+	if !ok {
+		log.Errorf("DNF:in->%s, out->%s, key->%v, not found in map", in.Input, in.Output, mapKey)
+		return nil, fmt.Errorf("DNF:in->%s, out->%s, key->%v, not found in map", in.Input, in.Output, mapKey)
+	}
+	NF_IN_PR := intfIds[0]
+	NF_OUT_PR := intfIds[1]
+	log.Infof("DNF: NF PRs index (IN)->%v, OUT->%v", NF_IN_PR, NF_OUT_PR)
 
-	if err := s.bridgeCtlr.DeletePort(AccIntfNames[NF_IN_PR_INTF_INDEX]); err != nil {
-		log.Errorf("failed to delete port to bridge: %v, for interface->%v", err, AccIntfNames[NF_IN_PR_INTF_INDEX])
-		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[NF_IN_PR_INTF_INDEX])
+	if err := s.bridgeCtlr.DeletePort(AccApfInfo[NF_IN_PR].Name); err != nil {
+		log.Errorf("failed to delete port to bridge: %v, for interface->%v", err, AccApfInfo[NF_IN_PR].Name)
+		FreeAccInterfaceForNF(intfIds)
+		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[NF_IN_PR].Name)
 	}
-	if err := s.bridgeCtlr.DeletePort(AccIntfNames[NF_OUT_PR_INTF_INDEX]); err != nil {
-		log.Errorf("failed to delete port to bridge: %v, for interface->%v", err, AccIntfNames[NF_OUT_PR_INTF_INDEX])
-		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccIntfNames[NF_OUT_PR_INTF_INDEX])
+	if err := s.bridgeCtlr.DeletePort(AccApfInfo[NF_OUT_PR].Name); err != nil {
+		log.Errorf("failed to delete port to bridge: %v, for interface->%v", err, AccApfInfo[NF_OUT_PR].Name)
+		FreeAccInterfaceForNF(intfIds)
+		return nil, fmt.Errorf("failed to add port to bridge: %v, for interface->%v", err, AccApfInfo[NF_OUT_PR].Name)
 	}
-	log.Infof("deleted interfaces:inPR->%s, outPR->%s", AccIntfNames[NF_IN_PR_INTF_INDEX], AccIntfNames[NF_OUT_PR_INTF_INDEX])
+	log.Infof("deleted interfaces:inPR->%s, outPR->%s", AccApfInfo[NF_IN_PR].Name, AccApfInfo[NF_OUT_PR].Name)
+
+	FreeAccInterfaceForNF(intfIds)
 
 	log.Infof("DeleteNFP4Rules, path->%s, 1-%v, 2-%v, 3-%v, 4-%v, 5-%v",
-		s.p4rtClient.GetBin(), vfMacList, in.Input, in.Output, AccApfMacList[NF_IN_PR_INTF_INDEX], AccApfMacList[NF_OUT_PR_INTF_INDEX])
-	p4rtclient.DeleteNFP4Rules(s.p4rtClient, vfMacList, in.Input, in.Output, AccApfMacList[NF_IN_PR_INTF_INDEX], AccApfMacList[NF_OUT_PR_INTF_INDEX])
+		s.p4rtClient.GetBin(), vfMacList, in.Input, in.Output, AccApfInfo[NF_IN_PR].Mac, AccApfInfo[NF_OUT_PR].Mac)
+	p4rtclient.DeleteNFP4Rules(s.p4rtClient, vfMacList, in.Input, in.Output, AccApfInfo[NF_IN_PR].Mac, AccApfInfo[NF_OUT_PR].Mac)
+	delete(s.nfReqMap, mapKey)
 
 	return &pb.Empty{}, nil
 }

--- a/ipu-plugin/pkg/ipuplugin/networkfunctionservice.go
+++ b/ipu-plugin/pkg/ipuplugin/networkfunctionservice.go
@@ -87,7 +87,7 @@ func deriveKey(in *pb.NFRequest) string {
 func (s *NetworkFunctionServiceServer) CreateNetworkFunction(ctx context.Context, in *pb.NFRequest) (*pb.Empty, error) {
 
 	mapKey := deriveKey(in)
-	intfIds, ok := s.nfReqMap[mapKey]
+	_, ok := s.nfReqMap[mapKey]
 	if ok {
 		log.Errorf("CNF:in->%s, out->%s, key->%v, exists in map", in.Input, in.Output, mapKey)
 		return nil, fmt.Errorf("CNF:in->%s, out->%s, key->%v, exists in map", in.Input, in.Output, mapKey)
@@ -101,7 +101,7 @@ func (s *NetworkFunctionServiceServer) CreateNetworkFunction(ctx context.Context
 
 	CheckAndAddPeerToPeerP4Rules(s.p4rtClient)
 
-	intfIds, err = AllocateAccInterfaceForNF()
+	intfIds, err := AllocateAccInterfaceForNF()
 	if err != nil {
 		log.Errorf("error from AllocateAccInterfaceForNF: %v, intfIds->%v", err, intfIds)
 		return nil, fmt.Errorf("error from AllocateAccInterfaceForNF: %v, intfIds->%v", err, intfIds)

--- a/ipu-plugin/pkg/types/types.go
+++ b/ipu-plugin/pkg/types/types.go
@@ -23,8 +23,8 @@ import (
 type BridgeType int
 
 type BridgePortInfo struct {
-	PbBrPort      *pb.BridgePort
-	PortInterface string
+	PbBrPort *pb.BridgePort
+	PortId   uint //For example, if ACC interface name is enp0s1f0d4, PortId(vportId) will be 4.
 }
 
 const (
@@ -32,6 +32,8 @@ const (
 	LinuxBridge
 	HostMode = "host"
 	IpuMode  = "ipu"
+	HostVfPr = "HostVfPr" // PR(port representator on ACC) for Host VF
+	NfPr     = "NfPr"     // PR(port representator on ACC) for Network Function
 )
 
 func (b BridgeType) String() string {

--- a/ipu-plugin/pkg/utils/utils.go
+++ b/ipu-plugin/pkg/utils/utils.go
@@ -180,19 +180,25 @@ func ImcQueryfindVsiGivenMacAddr(mode string, mac string) (string, error) {
 	return outputStr, err
 }
 
-// TODO: Use RunCliCmdOnImc in api below.
 // skips ACC interfaces D0 to D3, which are used internally. So, not available for other usages.
 // $2 == 4 is to get ACC entries, and $10 check is to make sure, we skip rows that has vportIDs from D0 to D3.
 func GetAvailableAccVsiList() ([]string, error) {
 	// reach out to the IMC
-	vsiList, err := ExecuteScript(`ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 root@192.168.0.1 "/usr/bin/cli_client -cq" \
-		| awk '{if(($2 == "0x4") && ($10 != "0x0") && ($10 != "0x1") && ($10 != "0x2") && ($10 != "0x3")) {print $8}}'`)
+	cliCmd := `set -o pipefail && cli_client -cq `
+	subCmd := ` | awk '{if(($2 == "0x4") && ($10 != "0x0") && ($10 != "0x1") && ($10 != "0x2") && ($10 != "0x3")) {print $8}}'`
+	outputBytes, err := RunCliCmdOnImc(cliCmd, subCmd)
 
-	if err != nil {
-		return nil, fmt.Errorf("unable to reach the IMC %v", err)
+	var outputStr []string
+	//Handle case where command ran without error, but empty output, due to config issue.
+	if (err != nil) || (len(outputBytes) == 0) {
+		log.Errorf("GetAvailableAccVsiList: Error %v, from RunCmdOnImc (OR) empty (output)-%v", err, len(outputBytes))
+		return outputStr, fmt.Errorf("GetAvailableAccVsiList: Error %v, from RunCmdOnImc (OR) empty (output)-%v", err, len(outputBytes))
 	}
 
-	return strings.Split(strings.TrimSpace(vsiList), "\n"), nil
+	outputStr = strings.Split(strings.TrimSpace(string(outputBytes)), "\n")
+	log.Infof("GetAvailableAccVsiList: %s, len(output)-%v", outputStr, len(outputStr))
+
+	return outputStr, err
 }
 
 // Note: Added retry logic, since ipumgmtd is single-threaded, so concurrent usage,
@@ -218,13 +224,6 @@ func RunCliCmdOnImc(cliCmd, subCmd string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to connect to %s: %w", imcAddress, err)
 	}
 	defer client.Close()
-
-	// Create SFTP client
-	sftpClient, err := sftp.NewClient(client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create SFTP client: %w", err)
-	}
-	defer sftpClient.Close()
 
 	var outputBytes []byte
 
@@ -252,12 +251,19 @@ func RunCliCmdOnImc(cliCmd, subCmd string) ([]byte, error) {
 			continue
 		}
 
-		// Copy output to file
-		if err := CopyFile(outputStr, "/work/cli_output", sftpClient); err != nil {
-			return nil, fmt.Errorf("failed to copy file: %w", err)
-		}
-
 		if subCmd != "" {
+			// Create SFTP client
+			sftpClient, err := sftp.NewClient(client)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create SFTP client: %w", err)
+			}
+			defer sftpClient.Close()
+
+			// Copy output to file
+			if err := CopyFile(outputStr, "/work/cli_output", sftpClient); err != nil {
+				return nil, fmt.Errorf("failed to copy file: %w", err)
+			}
+
 			// Execute the sub-command
 			session, err = client.NewSession()
 			if err != nil {


### PR DESCRIPTION
Support upto 16 Host VFs(pods), with increase of netdevs on ACC(to 48) 

 Supporting just 1 NF for TP. 
Needs debugging to support
    more NFs(past the first 16 netdevs on ACC). Ping
    from external client to NF ingress was not working
    for higher order netdevs(like D16 onwards). 
   Despite having function to use devmem commands to add all ACC netdevs to forwarding Group one.
