### PR TITLE
Synchronize VSP plugin pod and VSP P4 pod clean-up

### DIFF
--- a/ipu-plugin/pkg/infrapod/bindata/vsp-p4/99.vsp_p4.yaml
+++ b/ipu-plugin/pkg/infrapod/bindata/vsp-p4/99.vsp_p4.yaml
@@ -3,6 +3,8 @@ kind: DaemonSet
 metadata:
   name: vsp-p4
   namespace: {{.Namespace}}
+  finalizers:
+  - intel.com/waitForP4Deletion
 spec:
   selector:
     matchLabels:
@@ -14,7 +16,7 @@ spec:
     spec:
       nodeSelector:
         dpu: "true"
-      serviceAccountName: vsp-p4-sa
+      serviceAccountName: vsp-sa
       containers:
       - name: p4-container
         image: {{.ImageName}}

--- a/ipu-plugin/pkg/ipuplugin/ipuplugin.go
+++ b/ipu-plugin/pkg/ipuplugin/ipuplugin.go
@@ -169,7 +169,7 @@ func (s *server) Run() error {
 					syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 				}
 			}()
-			if err = s.infrapodMgr.DeleteCrs(); err != nil {
+			if err = s.infrapodMgr.DeleteCrs(true); err != nil {
 				log.Error(err, "unable to Delete Crs : %v", err)
 				return err
 			}
@@ -258,7 +258,7 @@ func (s *server) Stop() {
 		s.bridgeCtlr.DeleteBridges()
 		// Delete P4 rules on exit
 		cleanUpRulesOnExit(s.p4rtClient)
-		if err := s.infrapodMgr.DeleteCrs(); err != nil {
+		if err := s.infrapodMgr.DeleteCrs(false); err != nil {
 			log.Error(err, "unable to Delete Crs : %v", err)
 			// Do not return since we continue on error
 		}

--- a/ipu-plugin/pkg/types/types.go
+++ b/ipu-plugin/pkg/types/types.go
@@ -80,9 +80,10 @@ type P4RTClient interface {
 
 type InfrapodMgr interface {
 	StartMgr() error
+	RemoveDsFinalizer() error
 	CreateCrs() error
 	CreatePvCrs() error
-	DeleteCrs() error
+	DeleteCrs(ignoreFinalizer bool) error
 	WaitForPodDelete(timeout time.Duration) error
 	WaitForPodReady(timeout time.Duration) error
 }


### PR DESCRIPTION
It is necessary to have VSP P4 pod running when VSP plugin tries to clean-up the P4 entries when the microshift / openshift cluster removes the dpu operator configuration.

Finalizer object can be used to ensure that the P4 pod doesn't get cleaned up before VSP plugin is done with its exit.

finalizers are a built‐in mechanism you can use to ensure that “cleanup” or “synchronization” work happens before a resource is actually removed from etcd. In other words, finalizer let P4 pod delay the actual deletion of its object until VSP plugin pod have finished its clean-up activities.