### PR TITLE
Restore primary network upon vsp plugin cleanup

### DIFF
--- a/ipu-plugin/pkg/infrapod/bindata/vsp-p4/99.vsp_p4.yaml
+++ b/ipu-plugin/pkg/infrapod/bindata/vsp-p4/99.vsp_p4.yaml
@@ -3,6 +3,8 @@ kind: DaemonSet
 metadata:
   name: vsp-p4
   namespace: {{.Namespace}}
+  finalizers:
+  - intel.com/waitForP4Deletion
 spec:
   selector:
     matchLabels:
@@ -14,7 +16,7 @@ spec:
     spec:
       nodeSelector:
         dpu: "true"
-      serviceAccountName: vsp-p4-sa
+      serviceAccountName: vsp-sa
       containers:
       - name: p4-container
         image: {{.ImageName}}

--- a/ipu-plugin/pkg/ipuplugin/ipuplugin.go
+++ b/ipu-plugin/pkg/ipuplugin/ipuplugin.go
@@ -262,6 +262,8 @@ func (s *server) Stop() {
 			log.Error(err, "unable to Delete Crs : %v", err)
 			// Do not return since we continue on error
 		}
+		//Restore Red Hat primary network path via opcodes - This is required after the primiary network P4 rules are deleted.
+		utils.RestoreRHPrimaryNetwork()
 	}
 	// Stopping the gRPC server for the DPU daemon
 	s.grpcSrvr.GracefulStop()

--- a/ipu-plugin/pkg/ipuplugin/ipuplugin.go
+++ b/ipu-plugin/pkg/ipuplugin/ipuplugin.go
@@ -169,7 +169,7 @@ func (s *server) Run() error {
 					syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 				}
 			}()
-			if err = s.infrapodMgr.DeleteCrs(); err != nil {
+			if err = s.infrapodMgr.DeleteCrs(true); err != nil {
 				log.Error(err, "unable to Delete Crs : %v", err)
 				return err
 			}
@@ -258,7 +258,7 @@ func (s *server) Stop() {
 		s.bridgeCtlr.DeleteBridges()
 		// Delete P4 rules on exit
 		cleanUpRulesOnExit(s.p4rtClient)
-		if err := s.infrapodMgr.DeleteCrs(); err != nil {
+		if err := s.infrapodMgr.DeleteCrs(false); err != nil {
 			log.Error(err, "unable to Delete Crs : %v", err)
 			// Do not return since we continue on error
 		}

--- a/ipu-plugin/pkg/types/types.go
+++ b/ipu-plugin/pkg/types/types.go
@@ -80,9 +80,10 @@ type P4RTClient interface {
 
 type InfrapodMgr interface {
 	StartMgr() error
+	RemoveDsFinalizer() error
 	CreateCrs() error
 	CreatePvCrs() error
-	DeleteCrs() error
+	DeleteCrs(ignoreFinalizer bool) error
 	WaitForPodDelete(timeout time.Duration) error
 	WaitForPodReady(timeout time.Duration) error
 }

--- a/ipu-plugin/pkg/utils/utils.go
+++ b/ipu-plugin/pkg/utils/utils.go
@@ -489,3 +489,11 @@ func CopyBinary(imcPath string, vspPath string, sftpClient *sftp.Client) error {
 	}
 	return nil
 }
+
+func RestoreRHPrimaryNetwork() {
+        remoteCliCmd := "set -o pipefail && cli_client -x -f /tmp/tmp.*.txt"
+	_, err := RunCliCmdOnImc(remoteCliCmd, "")
+        if err != nil {
+               log.Info("RunCliCmdOnImc: Warning!. Unable to restore primary network access for to this IPU-ACC")
+        }
+}


### PR DESCRIPTION
Restore Red Hat primary network access upon vsp-plugin deletion

Whenever the vsp-plugin shuts down,it removes all P4 rules—including those for the primary network path. We need to re-install the opcodes that were configured during the IMC/ACC initialization phase so that the primary network path continues to work even without P4 rules, in accordance with the Red Hat data-path design.

This PR will restore Red Hat primiary network access by reprogramming the opcodes.
