### PR TITLE
Fix primary network restore logic

### DIFF
--- a/ipu-plugin/pkg/utils/utils.go
+++ b/ipu-plugin/pkg/utils/utils.go
@@ -491,7 +491,7 @@ func CopyBinary(imcPath string, vspPath string, sftpClient *sftp.Client) error {
 }
 
 func RestoreRHPrimaryNetwork() {
-        remoteCliCmd := "set -o pipefail && cli_client -x -f /tmp/tmp.*.txt"
+        remoteCliCmd := "set -o pipefail && /work/scripts/post_init_app.sh"
 	_, err := RunCliCmdOnImc(remoteCliCmd, "")
         if err != nil {
                log.Info("RunCliCmdOnImc: Warning!. Unable to restore primary network access for to this IPU-ACC")


### PR DESCRIPTION
Instead of re-run the existing / previously generated P4 opcodes specific to primary network, generate a new opcode with the updated vsi_id. This can simply be achieved by runing post_init_app.sh again during the vsp-plugin clean-up operation.