### PR TITLE
start redfish in post_init if a script for it exists

### DIFF
--- a/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -670,6 +670,8 @@ OPCODE_CFG_FILE=$(mktemp -p /tmp --suffix=.txt)
 sleep 1
 sync
 
+[ -e /work/scripts/start-redfish.sh ] && /work/scripts/start-redfish.sh
+
 exec 2>&1 1>${POST_INIT_LOG}
 
 pkill -9 $(basename ${PORT_SETUP_SCRIPT})


### PR DESCRIPTION
It is desired that redfish start persistently. The current guidance is to start it from within post_init_app.sh, as the network interface must already be up including waiting for DHCP, and if this is performed in the pre_init, there was a 10-second boot delay to accommodate this, which was not great. It does not belong in pre_init, it belongs in post.

So I propose we just run this other script from post_init if it exists (created by user or CDA), rather than trying to have something edit this file, or adding all the logic for that into this file. And if it hasn't been setup, then we pass by it silently.

It is not a problem to restart the redfish service, there is no chance of starting two instances, and since it is so rarely used, we have negligible risk of interrupting a redfish action if post_init is triggered by some other cleanup action.