### PR TITLE
Enable firewalld at ACC with restricted access

### DIFF
--- a/ipu-plugin/pkg/firewall/firewall.go
+++ b/ipu-plugin/pkg/firewall/firewall.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2025 Intel Corporation.  All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewall
+
+import (
+	"bytes"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// portRule defines a set of ports under a zone and protocol.
+type portRule struct {
+	Zone  string
+	Proto string
+	Ports []string
+}
+
+// trustedCIDRs are the subnets granted full access in the internal zone.
+var trustedCIDRs = []string{
+	"169.254.169.0/24",
+	"10.43.0.0/16",
+	"192.168.0.0/24",
+}
+
+// sshInterfaces defines which network interfaces are allowed SSH access.
+var sshInterfaces = []string{"enp0s1f0d1"} // customize your SSH interface here
+
+// portRules lists the ports opened per zone in configure mode.
+var portRules = []portRule{
+	{Zone: "internal", Proto: "tcp", Ports: []string{"9559", "8080", "443"}},
+	{Zone: "public", Proto: "tcp", Ports: []string{"22", "6443", "8445", "10250-10259"}},
+	{Zone: "public", Proto: "udp", Ports: []string{"53", "67-68"}},
+}
+
+// run executes a command and logs detailed errors on failure.
+func run(cmd string, args ...string) error {
+	full := append([]string{cmd}, args...)
+	log.Infof("executing command %s", strings.Join(full, " "))
+	c := exec.Command(cmd, args...)
+	var buf bytes.Buffer
+	c.Stdout, c.Stderr = &buf, &buf
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("%s failed: %w\n%s", strings.Join(full, " "), err, buf.String())
+	}
+	return nil
+}
+
+// runSilent executes a command without logging output.
+func runSilent(cmd string, args ...string) error {
+	return exec.Command(cmd, args...).Run()
+}
+
+// ensureService starts and enables a systemd service if not already running.
+func ensureService(name string) error {
+	if err := runSilent("systemctl", "is-active", "--quiet", name); err != nil {
+		log.Infof("starting service %s", name)
+		if err := run("systemctl", "start", name); err != nil {
+			return fmt.Errorf("start %s: %w", name, err)
+		}
+	}
+	if err := runSilent("systemctl", "enable", name); err != nil {
+		return fmt.Errorf("enable %s: %w", name, err)
+	}
+	return nil
+}
+
+// applyRules adds or removes firewall rules based on mode ("configure" or "cleanup").
+func applyRules(mode string) error {
+	// set default zone
+	zoneMap := map[string]string{"configure": "drop", "cleanup": "public"}
+	zone, ok := zoneMap[mode]
+	if !ok {
+		return fmt.Errorf("invalid mode %s", mode)
+	}
+	if err := run("firewall-cmd", "--set-default-zone="+zone); err != nil {
+		return fmt.Errorf("set default zone: %w", err)
+	}
+
+	// create or delete internal zone
+	if mode == "configure" {
+		_ = run("firewall-cmd", "--permanent", "--new-zone=internal")
+	} else {
+		_ = run("firewall-cmd", "--permanent", "--delete-zone=internal")
+	}
+
+	// prepare --permanent batch args
+	args := []string{"--permanent"}
+
+	// allow ingress (source) and egress (destination) for trusted CIDRs
+	for _, cidr := range trustedCIDRs {
+		// ingress rule via add/remove source
+		opSrc := "--add-source=" + cidr
+		// egress rule via rich rule
+		rule := fmt.Sprintf("rule family=\"ipv4\" destination address=\"%s\" accept", cidr)
+		opDst := fmt.Sprintf("--add-rich-rule=%s", rule)
+		// cleanup adjustments
+		if mode == "cleanup" {
+			opSrc = "--remove-source=" + cidr
+			// remove rich-rule syntax
+			rule = fmt.Sprintf("rule family=\"ipv4\" destination address=\"%s\" accept", cidr)
+			opDst = fmt.Sprintf("--remove-rich-rule=%s", rule)
+		}
+		args = append(args, "--zone=internal", opSrc, "--zone=internal", opDst)
+	}
+
+	// handle ports per rule
+	for _, rule := range portRules {
+		for _, p := range rule.Ports {
+			op := fmt.Sprintf("--add-port=%s/%s", p, rule.Proto)
+			if mode == "cleanup" {
+				op = fmt.Sprintf("--remove-port=%s/%s", p, rule.Proto)
+			}
+			args = append(args, fmt.Sprintf("--zone=%s", rule.Zone), op)
+		}
+	}
+
+	// SSH interface assignment (preserve cleanup for primary)
+	for _, iface := range sshInterfaces {
+		op := fmt.Sprintf("--add-interface=%s", iface)
+		if mode == "cleanup" {
+			// skip removal for primary SSH interface
+			if iface == sshInterfaces[0] {
+				continue
+			}
+			op = fmt.Sprintf("--remove-interface=%s", iface)
+		}
+		args = append(args, "--zone=public", op)
+	}
+
+	// mdns service and logging toggles
+	if mode == "configure" {
+		args = append(args, "--zone=public", "--remove-service=mdns", "--set-log-denied=all")
+	} else {
+		args = append(args, "--zone=public", "--add-service=mdns", "--set-log-denied=off")
+	}
+
+	// execute single batch command
+	cmd := append([]string{"firewall-cmd"}, args...)
+	return run(cmd[0], cmd[1:]...)
+}
+
+// Configure applies a hardened firewall configuration and reloads.
+func Configure() error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("must run as root")
+	}
+	if _, err := exec.LookPath("firewall-cmd"); err != nil {
+		return fmt.Errorf("firewalld not installed: %w", err)
+	}
+
+	if err := ensureService("firewalld"); err != nil {
+		return err
+	}
+
+	if err := applyRules("configure"); err != nil {
+		return err
+	}
+	if err := run("firewall-cmd", "--reload"); err != nil {
+		return fmt.Errorf("reload: %w", err)
+	}
+
+	log.Info("firewalld hardened successfully")
+	return nil
+}
+
+// CleanUp removes the hardened firewall configuration while preserving SSH connectivity.
+func CleanUp() error {
+	if err := ensureService("firewalld"); err != nil {
+		return err
+	}
+
+	if err := applyRules("cleanup"); err != nil {
+		return err
+	}
+	if err := run("firewall-cmd", "--reload"); err != nil {
+		return fmt.Errorf("reload after cleanup: %w", err)
+	}
+
+	log.Info("firewalld cleanup complete")
+	return nil
+}
+

--- a/ipu-plugin/pkg/ipuplugin/ipuplugin.go
+++ b/ipu-plugin/pkg/ipuplugin/ipuplugin.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
-
+        "github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/firewall"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/infrapod"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/p4rtclient"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/types"
@@ -151,6 +151,10 @@ func (s *server) Run() error {
 	if err != nil {
 		return fmt.Errorf("unable to run IPU plugin")
 	}
+        // Configure ACC firewall settings to allow microshift, dpu-operator, ACC-IMC internal traffics.
+        if err := firewall.Configure(); err != nil {
+		log.Error(err, "firewall setup failed: %v", err)
+	}
 
 	if s.mode == types.IpuMode {
 		log.Info("Starting infrapod")
@@ -271,6 +275,11 @@ func (s *server) Stop() {
 		s.listener.Close()
 		_ = s.cleanUp()
 	}
+        //Reset firewall to its default settings.
+        if err := firewall.CleanUp(); err != nil {
+                log.Error(err, "firewall cleanup failed: %v", err)
+        }
+
 	s.log.Info("IPU plugin has stopped")
 }
 


### PR DESCRIPTION
Enable firewalld at ACC with restricted access to allow only all the microshift, dpu-operator and ACC-IMC internal traffics.